### PR TITLE
Refactor shared site header and footer

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,8 +8,11 @@
   <link rel="icon" type="image/png" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="apple-touch-icon" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
+  <div data-include="/partials/header.html"></div>
+
   <section class="page-hero" style="text-align:center;padding:5rem 1rem">
     <div class="container">
       <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="EPS Logo" style="height:80px;width:80px;border-radius:20px;margin-bottom:1.5rem">
@@ -22,25 +25,6 @@
     </div>
   </section>
 
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://discord.gg/EkUYKmW">Discord</a>
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
-
-  <script>
-    // keep it simple: just set the year
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/assets/site.js
+++ b/assets/site.js
@@ -1,0 +1,76 @@
+(function(){
+  const THEME_KEY = 'eps-theme';
+
+  function persistTheme(theme){
+    try {
+      localStorage.setItem(THEME_KEY, theme);
+    } catch (err) {
+      // ignore storage issues (private mode, etc.)
+    }
+  }
+
+  function setTheme(theme){
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    persistTheme(theme);
+  }
+
+  function getStoredTheme(){
+    try {
+      return localStorage.getItem(THEME_KEY);
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function getTheme(){
+    return getStoredTheme() || 'dark';
+  }
+
+  function updateYear(){
+    const yearEl = document.getElementById('year');
+    if(yearEl){
+      yearEl.textContent = new Date().getFullYear();
+    }
+  }
+
+  function loadIncludes(){
+    const includeElements = document.querySelectorAll('[data-include]');
+    includeElements.forEach((el) => {
+      const src = el.getAttribute('data-include');
+      if(!src) return;
+      fetch(src)
+        .then((response) => {
+          if(!response.ok){
+            throw new Error(`Failed to load include: ${src} (${response.status})`);
+          }
+          return response.text();
+        })
+        .then((html) => {
+          el.innerHTML = html;
+          el.removeAttribute('data-include');
+          updateYear();
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    });
+  }
+
+  window.toggleTheme = function(){
+    const next = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+    setTheme(next);
+  };
+
+  setTheme(getTheme());
+
+  function init(){
+    loadIncludes();
+    updateYear();
+  }
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/games/deltazone-reloaded/index.html
+++ b/games/deltazone-reloaded/index.html
@@ -8,23 +8,10 @@
   <link rel="icon" type="image/png" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="apple-touch-icon" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <!-- NAVBAR -->
-  <header class="navbar">
-    <div class="container navbar-inner">
-      <a href="../../" class="logo">
-        <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="EPS Logo">
-        EvolvedPhoenix Studios
-      </a>
-      <nav class="nav-links">
-        <a class="nav-btn" href="../">Games</a>
-        <a class="nav-btn" href="../../news/">News</a>
-        <a class="nav-btn" href="../../team/">Team & Thanks</a>
-        <button class="nav-btn" onclick="toggleTheme()">Toggle Theme</button>
-      </nav>
-    </div>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <!-- HERO -->
   <section class="page-hero">
@@ -105,38 +92,11 @@
 	&nbsp;
 
   <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://discord.gg/EkUYKmW">Discord</a>
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 
-  <!-- INLINE JS: theme + year + buttons-only carousel with autoplay -->
+  <!-- INLINE JS: buttons-only carousel with autoplay -->
   <script>
     (function(){
-      // Theme
-      function setTheme(t){
-        document.documentElement.classList.toggle('dark', t==='dark');
-        try{ localStorage.setItem('eps-theme', t);}catch(e){}
-      }
-      const saved=(typeof localStorage!=='undefined' && localStorage.getItem('eps-theme')) || 'dark';
-      setTheme(saved);
-      window.toggleTheme = () => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark');
-
-      // Footer year
-      document.getElementById('year').textContent = new Date().getFullYear();
-
-      // Init carousels
       document.querySelectorAll('.carousel').forEach(setupCarousel);
 
       function setupCarousel(car){

--- a/games/gearbound-odyssey/index.html
+++ b/games/gearbound-odyssey/index.html
@@ -8,23 +8,10 @@
   <link rel="icon" type="image/png" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="apple-touch-icon" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <!-- NAVBAR -->
-  <header class="navbar">
-    <div class="container navbar-inner">
-      <a href="../../" class="logo">
-        <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="EPS Logo">
-        EvolvedPhoenix Studios
-      </a>
-      <nav class="nav-links">
-        <a class="nav-btn" href="../">Games</a>
-        <a class="nav-btn" href="../../news/">News</a>
-        <a class="nav-btn" href="../../team/">Team & Thanks</a>
-        <button class="nav-btn" onclick="toggleTheme()">Toggle Theme</button>
-      </nav>
-    </div>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <!-- HERO -->
   <section class="page-hero">
@@ -103,38 +90,11 @@
 	&nbsp;
 
   <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://discord.gg/EkUYKmW">Discord</a>
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 
-  <!-- INLINE JS: theme + year + buttons-only carousel with autoplay -->
+  <!-- INLINE JS: buttons-only carousel with autoplay -->
   <script>
     (function(){
-      // Theme
-      function setTheme(t){
-        document.documentElement.classList.toggle('dark', t==='dark');
-        try{ localStorage.setItem('eps-theme', t);}catch(e){}
-      }
-      const saved=(typeof localStorage!=='undefined' && localStorage.getItem('eps-theme')) || 'dark';
-      setTheme(saved);
-      window.toggleTheme = () => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark');
-
-      // Footer year
-      document.getElementById('year').textContent = new Date().getFullYear();
-
-      // Init carousels
       document.querySelectorAll('.carousel').forEach(setupCarousel);
 
       function setupCarousel(car){

--- a/games/index.html
+++ b/games/index.html
@@ -8,22 +8,10 @@
   <link rel="icon" type="image/jpg" href="/assets/images/1.jpg" />
   <link rel="apple-touch-icon" href="/assets/images/1.jpg" />
   <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <header class="navbar">
-    <div class="container navbar-inner">
-      <a href="../" class="logo">
-        <img src="/assets/images/1.jpg" alt="EPS Logo">
-        EvolvedPhoenix Studios
-      </a>
-      <nav class="nav-links">
-        <a class="nav-btn" href="../games/">Games</a>
-        <a class="nav-btn" href="../news/">News</a>
-        <a class="nav-btn" href="../team/">Team & Thanks</a>
-        <button class="nav-btn" onclick="toggleTheme()">Toggle Theme</button>
-      </nav>
-    </div>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <section class="page-hero">
     <div class="container">
@@ -287,34 +275,10 @@
   </section>
 	&nbsp;
 
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="/assets/images/1.jpg" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://discord.gg/EkUYKmW">Discord</a>
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 
  <script>
 (function () {
-  // ---------- theme + year in footer ----------
-  function setTheme(t){
-    document.documentElement.classList.toggle('dark', t === 'dark');
-    try { localStorage.setItem('eps-theme', t); } catch(e){}
-  }
-  const saved = (typeof localStorage!=='undefined' && localStorage.getItem('eps-theme')) || 'dark';
-  setTheme(saved);
-  window.toggleTheme = () => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark');
-  document.getElementById('year').textContent = new Date().getFullYear();
-
   // ---------- filtering ----------
   const search = document.getElementById('search');
   const cards  = Array.from(document.querySelectorAll('#grid .card'));

--- a/games/labyrinth-shadows-of-the-kingdom/index.html
+++ b/games/labyrinth-shadows-of-the-kingdom/index.html
@@ -8,23 +8,10 @@
   <link rel="icon" type="image/png" href="\assets\images\1.jpg" />
   <link rel="apple-touch-icon" href="\assets\images\1.jpg" />
   <link rel="stylesheet" href="../../assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <!-- NAVBAR -->
-  <header class="navbar">
-    <div class="container navbar-inner">
-      <a href="../../" class="logo">
-        <img src="\assets\images\1.jpg" alt="EPS Logo">
-        EvolvedPhoenix Studios
-      </a>
-      <nav class="nav-links">
-        <a class="nav-btn" href="../">Games</a>
-        <a class="nav-btn" href="../../news/">News</a>
-        <a class="nav-btn" href="../../team/">Team & Thanks</a>
-        <button class="nav-btn" onclick="toggleTheme()">Toggle Theme</button>
-      </nav>
-    </div>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <!-- HERO -->
   <section class="page-hero">
@@ -107,38 +94,11 @@
   </section>
 
   <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="\assets\images\1.jpg" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://discord.gg/EkUYKmW">Discord</a>
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 
-  <!-- INLINE JS: theme + year + buttons-only carousel with autoplay -->
+  <!-- INLINE JS: buttons-only carousel with autoplay -->
   <script>
     (function(){
-      // Theme
-      function setTheme(t){
-        document.documentElement.classList.toggle('dark', t==='dark');
-        try{ localStorage.setItem('eps-theme', t);}catch(e){}
-      }
-      const saved=(typeof localStorage!=='undefined' && localStorage.getItem('eps-theme')) || 'dark';
-      setTheme(saved);
-      window.toggleTheme = () => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark');
-
-      // Footer year
-      document.getElementById('year').textContent = new Date().getFullYear();
-
-      // Init carousels
       document.querySelectorAll('.carousel').forEach(setupCarousel);
 
       function setupCarousel(car){

--- a/games/turnburn/index.html
+++ b/games/turnburn/index.html
@@ -8,23 +8,10 @@
   <link rel="icon" type="image/png" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="apple-touch-icon" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <!-- NAVBAR -->
-  <header class="navbar">
-    <div class="container navbar-inner">
-      <a href="../../" class="logo">
-        <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="EPS Logo">
-        EvolvedPhoenix Studios
-      </a>
-      <nav class="nav-links">
-        <a class="nav-btn" href="../">Games</a>
-        <a class="nav-btn" href="../../news/">News</a>
-        <a class="nav-btn" href="../../team/">Team & Thanks</a>
-        <button class="nav-btn" onclick="toggleTheme()">Toggle Theme</button>
-      </nav>
-    </div>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <!-- HERO -->
   <section class="page-hero">
@@ -96,38 +83,11 @@
 	&nbsp;
 
   <!-- FOOTER -->
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://discord.gg/EkUYKmW">Discord</a>
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
+  <div data-include="/partials/footer.html"></div>
 
-  <!-- INLINE JS: theme + year + buttons-only carousel with autoplay -->
+  <!-- INLINE JS: buttons-only carousel with autoplay -->
   <script>
     (function(){
-      // Theme
-      function setTheme(t){
-        document.documentElement.classList.toggle('dark', t==='dark');
-        try{ localStorage.setItem('eps-theme', t);}catch(e){}
-      }
-      const saved=(typeof localStorage!=='undefined' && localStorage.getItem('eps-theme')) || 'dark';
-      setTheme(saved);
-      window.toggleTheme = () => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark');
-
-      // Footer year
-      document.getElementById('year').textContent = new Date().getFullYear();
-
-      // Init carousels
       document.querySelectorAll('.carousel').forEach(setupCarousel);
 
       function setupCarousel(car){

--- a/hidden/1640-JX/index.html
+++ b/hidden/1640-JX/index.html
@@ -13,6 +13,7 @@
   <link rel="icon" type="image/png" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="apple-touch-icon" href="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" />
   <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 
   <!-- Minimal fallbacks if your CSS doesn't already define these -->
   <style>
@@ -28,21 +29,7 @@
   </style>
 </head>
 <body>
-  <!-- Header / Nav (your structure) -->
-  <header class="navbar">
-    <div class="container navbar-inner">
-      <a href="/" class="logo">
-        <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="EPS Logo">
-        EvolvedPhoenix Studios
-      </a>
-      <nav class="nav-links">
-        <a class="nav-btn" href="/games/">Games</a>
-        <a class="nav-btn" href="/news/">News</a>
-        <a class="nav-btn" href="/team/">Team & Thanks</a>
-        <button class="nav-btn" onclick="toggleTheme()">Toggle Theme</button>
-      </nav>
-    </div>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <!-- Hero -->
   <section class="page-hero">
@@ -88,30 +75,6 @@
   </section>
 
   <!-- Footer (your structure) -->
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="https://static-cdn.jtvnw.net/jtv_user_pictures/eed6897e-342d-48ba-b9d0-aa0256278e71-profile_image-300x300.png" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://discord.gg/EkUYKmW">Discord</a>
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
-
-  <script>
-    (function(){
-      function setTheme(t){document.documentElement.classList.toggle('dark', t==='dark'); try{localStorage.setItem('eps-theme', t);}catch(e){}}
-      const saved = (typeof localStorage!=='undefined' && localStorage.getItem('eps-theme')) || 'dark';
-      setTheme(saved);
-      window.toggleTheme = () => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark');
-      document.getElementById('year').textContent = new Date().getFullYear();
-    })();
-  </script>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -8,22 +8,10 @@
   <link rel="icon" type="image/jpg" href="/assets/images/1.jpg" />
   <link rel="apple-touch-icon" href="/assets/images/1.jpg" />
   <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <header class="navbar">
-    <div class="container navbar-inner">
-      <a href="../" class="logo">
-        <img src="/assets/images/1.jpg" alt="EPS Logo">
-        EvolvedPhoenix Studios
-      </a>
-      <nav class="nav-links">
-        <a class="nav-btn" href="games/">Games</a>
-        <a class="nav-btn" href="news/">News</a>
-        <a class="nav-btn" href="team/">Team & Thanks</a>
-        <button class="nav-btn" onclick="toggleTheme()">Toggle Theme</button>
-      </nav>
-    </div>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <section class="page-hero">
     <div class="container">
@@ -188,30 +176,6 @@
   </section>
 	&nbsp;
 
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="/assets/images/1.jpg" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
-
-  <!-- tiny inline helpers -->
-  <script>
-    (function(){
-      function setTheme(t){document.documentElement.classList.toggle('dark', t==='dark'); try{localStorage.setItem('eps-theme', t);}catch(e){}}
-      const saved = (typeof localStorage!=='undefined' && localStorage.getItem('eps-theme')) || 'dark';
-      setTheme(saved);
-      window.toggleTheme = () => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark');
-      document.getElementById('year').textContent = new Date().getFullYear();
-    })();
-  </script>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/news/index.html
+++ b/news/index.html
@@ -8,22 +8,10 @@
   <link rel="icon" type="image/png" href="/assets/images/1.jpg" />
   <link rel="apple-touch-icon" href="/assets/images/1.jpg" />
   <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <header class="navbar">
-    <div class="container navbar-inner">
-      <a href="../" class="logo">
-        <img src="/assets/images/1.jpg" alt="EPS Logo">
-        EvolvedPhoenix Studios
-      </a>
-      <nav class="nav-links">
-        <a class="nav-btn" href="../games/">Games</a>
-        <a class="nav-btn" href="../news/">News</a>
-        <a class="nav-btn" href="../team/">Team & Thanks</a>
-        <button class="nav-btn" onclick="toggleTheme()">Toggle Theme</button>
-      </nav>
-    </div>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <section class="page-hero">
     <div class="container">
@@ -131,30 +119,6 @@
   </section>
 	&nbsp;
 
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="/assets/images/1.jpg" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://discord.gg/EkUYKmW">Discord</a>
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
-
-  <script>
-    (function(){
-      function setTheme(t){document.documentElement.classList.toggle('dark', t==='dark'); try{localStorage.setItem('eps-theme', t);}catch(e){}}
-      const saved = (typeof localStorage!=='undefined' && localStorage.getItem('eps-theme')) || 'dark';
-      setTheme(saved);
-      window.toggleTheme = () => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark');
-      document.getElementById('year').textContent = new Date().getFullYear();
-    })();
-  </script>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,15 @@
+<footer class="footer">
+  <div class="container flex items-center justify-between">
+    <div class="flex items-center gap-2">
+      <img src="/assets/images/1.jpg" alt="" style="height:40px;width:40px;border-radius:14px">
+      <strong>EvolvedPhoenix Studios</strong>
+    </div>
+    <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
+    <div class="flex gap-3">
+      <a href="https://discord.gg/EkUYKmW">Discord</a>
+      <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
+      <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
+      <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
+    </div>
+  </div>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,14 @@
+<header class="navbar">
+  <div class="container navbar-inner">
+    <a href="/" class="logo">
+      <img src="/assets/images/1.jpg" alt="EPS Logo">
+      EvolvedPhoenix Studios
+    </a>
+    <nav class="nav-links">
+      <a class="nav-btn" href="/games/">Games</a>
+      <a class="nav-btn" href="/news/">News</a>
+      <a class="nav-btn" href="/team/">Team & Thanks</a>
+      <button class="nav-btn" type="button" onclick="toggleTheme()">Toggle Theme</button>
+    </nav>
+  </div>
+</header>

--- a/team/index.html
+++ b/team/index.html
@@ -8,22 +8,10 @@
   <link rel="icon" type="image/png" href="/assets/images/1.jpg" />
   <link rel="apple-touch-icon" href="/assets/images/1.jpg" />
   <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
 </head>
 <body>
-  <header class="navbar">
-    <div class="container navbar-inner">
-      <a href="../" class="logo">
-        <img src="/assets/images/1.jpg" alt="EPS Logo">
-        EvolvedPhoenix Studios
-      </a>
-      <nav class="nav-links">
-        <a class="nav-btn" href="../games/">Games</a>
-        <a class="nav-btn" href="../news/">News</a>
-        <a class="nav-btn" href="../team/">Team & Thanks</a>
-        <button class="nav-btn" onclick="toggleTheme()">Toggle Theme</button>
-      </nav>
-    </div>
-  </header>
+  <div data-include="/partials/header.html"></div>
 
   <section class="page-hero">
     <div class="container">
@@ -131,30 +119,6 @@
   
 	&nbsp;
 
-  <footer class="footer">
-    <div class="container flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <img src="/assets/images/1.jpg" alt="" style="height:40px;width:40px;border-radius:14px">
-        <strong>EvolvedPhoenix Studios</strong>
-      </div>
-      <div>© <span id="year"></span> EvolvedPhoenix Studios</div>
-      <div class="flex gap-3">
-        <a href="https://discord.gg/EkUYKmW">Discord</a>
-        <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
-        <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
-        <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
-      </div>
-    </div>
-  </footer>
-
-  <script>
-    (function(){
-      function setTheme(t){document.documentElement.classList.toggle('dark', t==='dark'); try{localStorage.setItem('eps-theme', t);}catch(e){}}
-      const saved = (typeof localStorage!=='undefined' && localStorage.getItem('eps-theme')) || 'dark';
-      setTheme(saved);
-      window.toggleTheme = () => setTheme(document.documentElement.classList.contains('dark') ? 'light' : 'dark');
-      document.getElementById('year').textContent = new Date().getFullYear();
-    })();
-  </script>
+  <div data-include="/partials/footer.html"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable header and footer partials along with a loader script
- update site pages to pull in the shared markup and consolidate theme/year logic

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6b64e689883328fba58c737a21ff0