### PR TITLE
Add login page backed by secure auth service

### DIFF
--- a/assets/login.js
+++ b/assets/login.js
@@ -1,0 +1,98 @@
+(function(){
+  const AUTH_ENDPOINT = 'https://auth.evolvedphoenixstudios.com/api/login';
+  const STORAGE_KEY = 'eps-auth-token';
+
+  function setFeedback(message, variant){
+    const feedbackEl = document.getElementById('login-feedback');
+    if(!feedbackEl){
+      return;
+    }
+    feedbackEl.textContent = message;
+    feedbackEl.style.color = variant === 'error' ? '#dc2626' : '#16a34a';
+  }
+
+  async function requestLogin(username, password){
+    const response = await fetch(AUTH_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ username, password })
+    });
+
+    if(!response.ok){
+      const errorText = await response.text().catch(() => '');
+      const detail = errorText ? `: ${errorText}` : '';
+      throw new Error(`Login failed${detail}`);
+    }
+
+    return response.json();
+  }
+
+  function persistToken(token){
+    try {
+      sessionStorage.setItem(STORAGE_KEY, token);
+    } catch (err) {
+      console.warn('Unable to persist login token in session storage', err);
+    }
+  }
+
+  function handleSuccess(payload){
+    if(payload && payload.token){
+      persistToken(payload.token);
+      setFeedback('Signed in successfully. Redirecting…', 'success');
+      const redirect = payload.redirectUrl || '/';
+      setTimeout(() => {
+        window.location.href = redirect;
+      }, 800);
+    } else {
+      setFeedback('Signed in, but no session token was returned.', 'error');
+    }
+  }
+
+  function setLoading(loading){
+    const submitBtn = document.getElementById('login-submit');
+    if(submitBtn){
+      submitBtn.disabled = loading;
+      submitBtn.textContent = loading ? 'Signing in…' : 'Sign in';
+    }
+  }
+
+  function onSubmit(event){
+    event.preventDefault();
+    const form = event.currentTarget;
+    const username = form.username.value.trim();
+    const password = form.password.value;
+
+    if(!username || !password){
+      setFeedback('Enter both a username and password to continue.', 'error');
+      return;
+    }
+
+    setLoading(true);
+    setFeedback('Contacting secure server…', 'success');
+
+    requestLogin(username, password)
+      .then(handleSuccess)
+      .catch((error) => {
+        console.error(error);
+        setFeedback(error.message || 'Unable to sign in. Try again in a moment.', 'error');
+      })
+      .finally(() => setLoading(false));
+  }
+
+  function init(){
+    const form = document.getElementById('login-form');
+    if(!form){
+      return;
+    }
+
+    form.addEventListener('submit', onSubmit);
+  }
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/login/index.html
+++ b/login/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>EvolvedPhoenix Studios — Account Login</title>
+  <meta name="description" content="Log in to access member-only features on EvolvedPhoenix Studios." />
+  <link rel="icon" type="image/jpg" href="/assets/images/1.jpg" />
+  <link rel="apple-touch-icon" href="/assets/images/1.jpg" />
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
+  <script src="/assets/login.js" defer></script>
+</head>
+<body>
+  <div data-include="/partials/header.html"></div>
+
+  <main class="container" style="max-width:640px;margin-top:4rem;margin-bottom:4rem;">
+    <section class="card">
+      <div class="card-body">
+        <h1 style="margin:0 0 .75rem;font:800 1.8rem/1.2 system-ui">Welcome back</h1>
+        <p style="color:#475569;margin:0 0 1.5rem;">Sign in with your studio account to manage builds, playtests, and community tools.</p>
+        <form id="login-form" class="grid" style="gap:1rem;">
+          <label class="grid" style="gap:.5rem;">
+            <span class="label">Username</span>
+            <input id="username" name="username" type="text" required autocomplete="username" class="input" placeholder="alex.mercer" />
+          </label>
+          <label class="grid" style="gap:.5rem;">
+            <span class="label">Password</span>
+            <input id="password" name="password" type="password" required autocomplete="current-password" class="input" placeholder="••••••••" />
+          </label>
+          <button id="login-submit" type="submit" class="btn btn-primary" style="justify-self:start;">Sign in</button>
+        </form>
+        <div id="login-feedback" role="status" aria-live="polite" style="margin-top:1rem;font:600 0.95rem/1.4 system-ui;"></div>
+      </div>
+    </section>
+
+    <section class="card" style="margin-top:2rem;">
+      <div class="card-body">
+        <h2 style="margin:0 0 .5rem;font:700 1.2rem/1.3 system-ui;">Account security</h2>
+        <p style="color:#475569;margin:0;">Credentials are submitted to our secure authentication service over HTTPS. We never store passwords in the website codebase. If you suspect your account has been compromised, reset it immediately through the account portal.</p>
+      </div>
+    </section>
+  </main>
+
+  <div data-include="/partials/footer.html"></div>
+</body>
+</html>

--- a/partials/header.html
+++ b/partials/header.html
@@ -8,6 +8,7 @@
       <a class="nav-btn" href="/games/">Games</a>
       <a class="nav-btn" href="/news/">News</a>
       <a class="nav-btn" href="/team/">Team & Thanks</a>
+      <a class="nav-btn" href="/login/">Login</a>
       <button class="nav-btn" type="button" onclick="toggleTheme()">Toggle Theme</button>
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- add a dedicated login page with username/password form and security messaging
- create client-side logic to call the secure authentication service and persist the returned token
- expose the login page from the global navigation

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dc5396adfc83328273a24b5cdf49be