### PR TITLE
Add Express login API and configurable auth script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -54,3 +54,44 @@ If you are interested in collaboration or licensing, please contact us directly.
 
 © EvolvedPhoenix Studios. All rights reserved.  
 This repository is provided publicly for transparency. **It is not open source.**
+
+---
+
+## 🧪 Local Development
+
+You can run the static site together with a simple API server for local testing.
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) 18 or newer
+- npm (bundled with Node.js)
+
+### Installation
+
+```bash
+npm install
+```
+
+### Running the server
+
+```bash
+npm start
+```
+
+The site and API will be available at [http://localhost:3000](http://localhost:3000).
+
+### Test credentials
+
+| Username | Password |
+| -------- | -------- |
+| admin    | password |
+
+You can override the defaults by creating a `.env` file at the project root:
+
+```ini
+LOGIN_CREDENTIALS=admin:password,anotherUser:anotherSecret
+LOGIN_REDIRECT_URL=/dashboard.html
+PORT=3000
+```
+
+If you change the port or host, update your browser URL accordingly.

--- a/assets/login.js
+++ b/assets/login.js
@@ -1,0 +1,65 @@
+(function () {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const currentScript = document.currentScript;
+  const dataEndpoint = currentScript && currentScript.dataset
+    ? currentScript.dataset.authEndpoint
+    : undefined;
+
+  const AUTH_ENDPOINT = dataEndpoint || window.AUTH_ENDPOINT || '/api/login';
+
+  async function submitLogin(event) {
+    event.preventDefault();
+
+    const form = event.target;
+    const formData = new FormData(form);
+    const username = formData.get('username');
+    const password = formData.get('password');
+
+    const status = form.querySelector('[data-login-status]');
+    if (status) {
+      status.textContent = 'Signing in…';
+    }
+
+    try {
+      const response = await fetch(AUTH_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload && payload.message ? payload.message : 'Login failed');
+      }
+
+      if (status) {
+        status.textContent = 'Success! Redirecting…';
+      }
+
+      if (payload.redirectUrl) {
+        window.location.href = payload.redirectUrl;
+      }
+    } catch (error) {
+      if (status) {
+        status.textContent = error.message;
+      } else {
+        console.error(error);
+      }
+    }
+  }
+
+  const form = document.querySelector('[data-login-form]');
+  if (form) {
+    form.addEventListener('submit', submitLogin);
+  }
+
+  window.EPSLogin = {
+    submitLogin,
+    AUTH_ENDPOINT,
+  };
+})();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "evolved-phoenix-studios",
+  "version": "1.0.0",
+  "description": "Static site with bundled Express server",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.1",
+    "express": "^4.19.2"
+  }
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,76 @@
+const path = require('path');
+const express = require('express');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+const credentialPairs = (process.env.LOGIN_CREDENTIALS || 'admin:password').split(',');
+const credentials = new Map(
+  credentialPairs
+    .map((pair) => pair.trim())
+    .filter(Boolean)
+    .map((pair) => {
+      const [username, password] = pair.split(':');
+      if (!username || typeof password === 'undefined') {
+        return null;
+      }
+      return [username, password];
+    })
+    .filter(Boolean)
+);
+
+const redirectUrl = process.env.LOGIN_REDIRECT_URL || '/';
+
+app.use(express.json());
+
+app.post('/api/login', (req, res, next) => {
+  try {
+    const { username, password } = req.body || {};
+
+    if (!username || !password) {
+      return res
+        .status(400)
+        .json({ message: 'Username and password are required.' });
+    }
+
+    const expectedPassword = credentials.get(username);
+    if (!expectedPassword || expectedPassword !== password) {
+      return res
+        .status(401)
+        .json({ message: 'Incorrect username or password. Please try again.' });
+    }
+
+    return res.json({
+      token: `mock-token-${Buffer.from(username).toString('hex')}`,
+      redirectUrl,
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+app.use(
+  express.static(path.resolve(__dirname, '..'), {
+    extensions: ['html'],
+    fallthrough: true,
+  })
+);
+
+app.use((req, res, next) => {
+  if (req.method === 'GET') {
+    return res.sendFile(path.resolve(__dirname, '..', 'index.html'));
+  }
+  return next();
+});
+
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ message: 'An unexpected error occurred.' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add an Express server that serves the static site and exposes a /api/login endpoint with credential validation and error handling
- provide a configurable front-end login helper that defaults to the bundled API endpoint
- document local setup steps, dependencies, and default credentials while ignoring local environment artifacts

## Testing
- npm install *(fails: 403 Forbidden when downloading dependencies from the npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc6218c1ec8332a661db07292ecd99