### PR TITLE
Add company-wide terms of service page

### DIFF
--- a/partials/footer.html
+++ b/partials/footer.html
@@ -10,6 +10,7 @@
       <a href="https://www.youtube.com/@EvolvedPhoenix-Studios">YouTube</a>
       <a href="https://x.com/EvolvedPhnixDev">X / Twitter</a>
       <a href="https://github.com/EvolvedPhoenixOfficial">GitHub</a>
+      <a href="/terms-of-service.html">Terms of Service</a>
     </div>
   </div>
 </footer>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -17,15 +17,15 @@
     <section class="page-hero" style="padding-block:3rem 1.5rem;">
       <div class="container" style="max-width:840px;margin-inline:auto;">
         <h1>EvolvedPhoenix Studios — Terms of Participation</h1>
-        <p class="mt-2" style="color:#475569;">These Terms govern contributions to EvolvedPhoenix Studios projects and initiatives.</p>
-        <p class="mt-3" style="font-size:0.95rem;color:#1f2937;">Last updated: October 9, 2025</p>
-        <p class="mt-1" style="font-size:0.95rem;color:#1f2937;">Studio: EvolvedPhoenix Studios (&ldquo;Studio&rdquo;)</p>
-        <p class="mt-1" style="font-size:0.95rem;color:#1f2937;">You: the individual accepting these terms (&ldquo;Participant&rdquo;)</p>
-        <p class="mt-4" style="color:#1f2937;">By checking &ldquo;I agree,&rdquo; e-signing, or otherwise consenting, you enter a binding agreement with Studio.</p>
+        <p class="mt-2" style="color:#477590;">These Terms govern contributions to EvolvedPhoenix Studios projects and initiatives.</p>
+        <p class="mt-3" style="font-size:0.95rem;color:#477590;">Last updated: October 9, 2025</p>
+        <p class="mt-1" style="font-size:0.95rem;color:#477590;">Studio: EvolvedPhoenix Studios (&ldquo;Studio&rdquo;)</p>
+        <p class="mt-1" style="font-size:0.95rem;color:#477590;">You: the individual accepting these terms (&ldquo;Participant&rdquo;)</p>
+        <p class="mt-4" style="color:#477590;">By checking &ldquo;I agree,&rdquo; e-signing, or otherwise consenting, you enter a binding agreement with Studio.</p>
       </div>
     </section>
 
-    <section style="max-width:840px;margin-inline:auto;display:flex;flex-direction:column;gap:1.75rem;font-size:0.98rem;color:#1f2937;">
+    <section style="max-width:840px;margin-inline:auto;display:flex;flex-direction:column;gap:1.75rem;font-size:0.98rem;color:#477590;">
       <article>
         <h2>1) Scope &amp; Roles</h2>
         <p>These Terms apply to any contribution you make to any current or future EvolvedPhoenix Studios project in any role, including without limitation: Voice Actor, 3D Artist/Modeler, Composer/Sound Designer, Animator, Writer, Concept Artist, Playtester, QA, community moderator, producer, or other contributor (collectively, &ldquo;Contributions&rdquo;).</p>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1,0 +1,141 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>EvolvedPhoenix Studios — Terms of Service</title>
+  <meta name="description" content="Terms governing participation and contributions to EvolvedPhoenix Studios projects." />
+  <link rel="icon" type="image/jpg" href="/assets/images/1.jpg" />
+  <link rel="apple-touch-icon" href="/assets/images/1.jpg" />
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
+</head>
+<body>
+  <div data-include="/partials/header.html"></div>
+
+  <main class="container mb-8">
+    <section class="page-hero" style="padding-block:3rem 1.5rem;">
+      <div class="container" style="max-width:840px;margin-inline:auto;">
+        <h1>EvolvedPhoenix Studios — Terms of Participation</h1>
+        <p class="mt-2" style="color:#475569;">These Terms govern contributions to EvolvedPhoenix Studios projects and initiatives.</p>
+        <p class="mt-3" style="font-size:0.95rem;color:#1f2937;">Last updated: October 9, 2025</p>
+        <p class="mt-1" style="font-size:0.95rem;color:#1f2937;">Studio: EvolvedPhoenix Studios (&ldquo;Studio&rdquo;)</p>
+        <p class="mt-1" style="font-size:0.95rem;color:#1f2937;">You: the individual accepting these terms (&ldquo;Participant&rdquo;)</p>
+        <p class="mt-4" style="color:#1f2937;">By checking &ldquo;I agree,&rdquo; e-signing, or otherwise consenting, you enter a binding agreement with Studio.</p>
+      </div>
+    </section>
+
+    <section style="max-width:840px;margin-inline:auto;display:flex;flex-direction:column;gap:1.75rem;font-size:0.98rem;color:#1f2937;">
+      <article>
+        <h2>1) Scope &amp; Roles</h2>
+        <p>These Terms apply to any contribution you make to any current or future EvolvedPhoenix Studios project in any role, including without limitation: Voice Actor, 3D Artist/Modeler, Composer/Sound Designer, Animator, Writer, Concept Artist, Playtester, QA, community moderator, producer, or other contributor (collectively, &ldquo;Contributions&rdquo;).</p>
+      </article>
+
+      <article>
+        <h2>2) Work-Made-for-Hire; Assignment &amp; License</h2>
+        <ol style="padding-left:1.25rem;display:flex;flex-direction:column;gap:0.75rem;">
+          <li><strong>Work-Made-for-Hire.</strong> To the maximum extent permitted by law, your Contributions are &ldquo;works made for hire&rdquo; for Studio.</li>
+          <li><strong>Assignment (fallback).</strong> If any Contribution is not &ldquo;work-made-for-hire,&rdquo; you hereby irrevocably assign to Studio all right, title, and interest in and to the Contribution, including all worldwide intellectual property rights, in perpetuity.</li>
+          <li><strong>License (backup to assignment).</strong> If any assignment fails for any reason, you grant Studio an exclusive, perpetual, worldwide, irrevocable, transferable, royalty-free license (with the right to sublicense) to use, reproduce, adapt, modify, distribute, perform, display, advertise, market, and otherwise exploit the Contribution in any media now known or later developed.</li>
+          <li><strong>Moral Rights Waiver.</strong> To the fullest extent permitted, you waive (and agree not to assert) any so-called moral rights (e.g., rights of attribution, integrity, withdrawal) and similar claims in your Contributions.</li>
+        </ol>
+      </article>
+
+      <article>
+        <h2>3) Voice, Likeness, and Performance Release (Voice Actors &amp; Anyone Recorded)</h2>
+        <p>You grant Studio the perpetual, worldwide, irrevocable right to record, use, edit, synchronize, reproduce, distribute, publicly perform, and otherwise exploit your voice, likeness, performance, name, and biographical information in connection with any EvolvedPhoenix Studios project, sequels, updates, downloadable content, ports, marketing, trailers, social posts, and any related or derivative works.</p>
+        <p><strong>No Retraction/Take-Down.</strong> You cannot later demand removal of your voice/performance or sue to have it taken out. You expressly waive any rights of approval or injunctive relief.</p>
+      </article>
+
+      <article>
+        <h2>4) 3D Models, Art, Audio, Code &amp; Other Assets (Artists/Developers)</h2>
+        <p>All models, textures, rigs, animations, VFX, SFX, music, code, tools, documentation, builds, and other assets you create as Contributions are owned by Studio under Sections 2.1&ndash;2.3.</p>
+        <p><strong>No Retraction/Take-Down.</strong> You cannot later sue to remove the assets from Studio projects, stores, builds, marketing, or related works.</p>
+      </article>
+
+      <article>
+        <h2>5) Playtesting &amp; Confidentiality (NDA)</h2>
+        <ol style="padding-left:1.25rem;display:flex;flex-direction:column;gap:0.75rem;">
+          <li><strong>Confidential Information.</strong> All non-public information you learn (gameplay, builds, mechanics, art, narrative, tools, bugs, schedules, chats, docs, roadmaps, community plans, etc.) is Confidential.</li>
+          <li><strong>Non-Disclosure.</strong> You must not disclose, record, stream, capture, post, or share any Confidential Information without Studio&rsquo;s written permission.</li>
+          <li><strong>No Leaks.</strong> Uploading, sharing, or transmitting gameplay footage, builds, screenshots, or documents without authorization is a material breach.</li>
+          <li><strong>Security.</strong> You&rsquo;ll use reasonable measures to keep test builds and tools safe (no public links, no shared drives, no reverse engineering).</li>
+        </ol>
+      </article>
+
+      <article>
+        <h2>6) No Injunctive Relief; Remedies</h2>
+        <p>You waive the right to seek or obtain injunctive or other equitable relief that would restrain or interfere with Studio&rsquo;s use, distribution, or exploitation of any EvolvedPhoenix Studios project or the Contributions. Monetary damages (if any) are your sole remedy. Studio may pursue all available remedies (including temporary restraining orders/injunctions to stop leaks or ongoing misuse of Confidential Information).</p>
+      </article>
+
+      <article>
+        <h2>7) Credits (At Studio&rsquo;s Discretion)</h2>
+        <p>Studio may credit you in-game or in materials, but credit style, placement, and inclusion are at Studio&rsquo;s discretion and may vary by platform, port, localization, or project.</p>
+      </article>
+
+      <article>
+        <h2>8) No Expectation of Compensation (Unless Separately Agreed)</h2>
+        <p>Unless the parties sign a separate written agreement specifying payment terms, you acknowledge your participation may be unpaid and you are not owed wages, royalties, residuals, or other compensation. If a separate agreement exists, these Terms supplement it; if there&rsquo;s a conflict, the separate agreement controls payment.</p>
+      </article>
+
+      <article>
+        <h2>9) Representations &amp; Warranties</h2>
+        <ul style="padding-left:1.25rem;display:flex;flex-direction:column;gap:0.75rem;">
+          <li>Your Contributions are your original work (or you have all necessary rights to contribute them) and do not infringe any third-party rights.</li>
+          <li>You are 18 or older (or of legal age in your jurisdiction) and legally able to enter this agreement.</li>
+          <li>Your participation does not violate any other agreement or obligation.</li>
+          <li>No malware, spyware, or harmful code will be included in your Contributions.</li>
+        </ul>
+      </article>
+
+      <article>
+        <h2>10) Indemnity</h2>
+        <p>You will defend, indemnify, and hold harmless Studio, its affiliates, and their personnel from any claims, damages, and expenses (including reasonable attorneys&rsquo; fees) arising out of (a) your breach of these Terms, (b) your Contributions, or (c) your leaks or misuse of Confidential Information.</p>
+      </article>
+
+      <article>
+        <h2>11) Ownership of Tools &amp; Materials</h2>
+        <p>All engines, tools, pipelines, documents, and infrastructure provided by Studio remain Studio property. Any improvements or feedback you provide may be used by Studio without restriction.</p>
+      </article>
+
+      <article>
+        <h2>12) Term &amp; Termination</h2>
+        <p>These Terms begin when you consent and continue perpetually as to rights granted. Studio may terminate your participation at any time for any reason. Sections intended to survive (including 2&ndash;6, 8&ndash;13, 15&ndash;17) survive termination.</p>
+      </article>
+
+      <article>
+        <h2>13) Export &amp; Compliance</h2>
+        <p>You will comply with applicable laws and will not export or share builds or tools in violation of law, sanctions, or restrictions.</p>
+      </article>
+
+      <article>
+        <h2>14) Privacy &amp; Recording Notice</h2>
+        <p>Testing sessions, calls, or submissions may be recorded for quality assurance and production purposes. You consent to such recording and use in connection with development and support of Studio projects.</p>
+      </article>
+
+      <article>
+        <h2>15) Limitation of Liability</h2>
+        <p>To the maximum extent permitted by law, Studio is not liable for indirect, incidental, special, consequential, exemplary, or punitive damages. Studio&rsquo;s total liability for any claim related to these Terms or your participation will not exceed USD $100.</p>
+      </article>
+
+      <article>
+        <h2>16) Governing Law; Venue; Dispute Resolution</h2>
+        <p>These Terms are governed by the laws of the State of Maryland, without regard to conflicts-of-law principles. You consent to the exclusive jurisdiction and venue of state and federal courts located in Maryland. Either party may also seek immediate equitable relief to prevent or stop leaks or misuse of Confidential Information.</p>
+      </article>
+
+      <article>
+        <h2>17) Miscellaneous</h2>
+        <ul style="padding-left:1.25rem;display:flex;flex-direction:column;gap:0.75rem;">
+          <li><strong>Entire Agreement.</strong> These Terms are the entire agreement regarding your participation with Studio and supersede prior discussions.</li>
+          <li><strong>Amendments.</strong> Changes must be in a writing signed by Studio (posting updated Terms for new sign-ups counts for future participants).</li>
+          <li><strong>Severability.</strong> If any provision is unenforceable, the rest remains in effect.</li>
+          <li><strong>Assignment.</strong> Studio may assign these Terms; you may not assign without Studio&rsquo;s consent.</li>
+          <li><strong>Electronic Consent.</strong> You agree that checking a box, e-signing, or clicking &ldquo;I agree&rdquo; constitutes your binding signature.</li>
+        </ul>
+      </article>
+    </section>
+  </main>
+
+  <div data-include="/partials/footer.html"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a company-wide terms of participation page outlining contributor obligations
- link the global footer to the new terms page for easy discovery

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e028acaa188332a3edbe940bbeccb5