### PR TITLE
Add community forum demo page with local posting

### DIFF
--- a/account/index.html
+++ b/account/index.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Account Manager — Extynct Studios</title>
+  <meta name="description" content="Create and manage your Extynct Studios forum account. Accounts are stored locally in your browser." />
+  <link rel="icon" type="image/png" href="/assets/images/8.jpg" />
+  <link rel="apple-touch-icon" href="/assets/images/8.jpg" />
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
+  <script src="/assets/account.js" defer></script>
+</head>
+<body>
+  <div data-include="/partials/header.html"></div>
+
+  <main id="account-root" class="account">
+    <section class="page-hero">
+      <div class="container">
+        <h1>Manage your account</h1>
+        <p class="account-subtitle">Create a sign-in you can use for the community forum on this device. All data is stored locally and never leaves your browser.</p>
+      </div>
+    </section>
+
+    <section class="container account-layout">
+      <article class="card account-card" aria-labelledby="account-create-heading">
+        <div class="card-body">
+          <h2 id="account-create-heading" class="account-card-title">Create a new account</h2>
+          <p class="account-card-intro">Use a unique username and a password with at least eight characters. Your email helps identify the account if you create more than one.</p>
+
+          <form id="account-create-form" class="account-form" novalidate>
+            <div class="account-field">
+              <label for="account-create-username">Username <span aria-hidden="true">*</span></label>
+              <input id="account-create-username" name="username" type="text" maxlength="32" autocomplete="username" required placeholder="Ex: DriftPilot" />
+            </div>
+
+            <div class="account-field">
+              <label for="account-create-email">Email <span aria-hidden="true">*</span></label>
+              <input id="account-create-email" name="email" type="email" maxlength="120" autocomplete="email" required placeholder="you@example.com" />
+            </div>
+
+            <div class="account-field">
+              <label for="account-create-password">Password <span aria-hidden="true">*</span></label>
+              <input id="account-create-password" name="password" type="password" minlength="8" maxlength="64" autocomplete="new-password" required placeholder="At least 8 characters" />
+            </div>
+
+            <div class="account-field">
+              <label for="account-create-confirm">Confirm password <span aria-hidden="true">*</span></label>
+              <input id="account-create-confirm" name="confirm" type="password" minlength="8" maxlength="64" autocomplete="new-password" required placeholder="Re-enter password" />
+            </div>
+
+            <p id="account-create-error" class="account-error" role="alert" hidden></p>
+            <p id="account-create-success" class="account-success" role="status" hidden></p>
+
+            <button type="submit" class="btn btn-primary">Create account</button>
+          </form>
+        </div>
+      </article>
+
+      <article class="card account-card" aria-labelledby="account-signin-heading">
+        <div class="card-body">
+          <h2 id="account-signin-heading" class="account-card-title">Sign in</h2>
+          <p class="account-card-intro">Already created an account on this device? Sign in with your email or username and password.</p>
+
+          <form id="account-signin-form" class="account-form" novalidate>
+            <div class="account-field">
+              <label for="account-signin-identifier">Email or username <span aria-hidden="true">*</span></label>
+              <input id="account-signin-identifier" name="identifier" type="text" autocomplete="username" required placeholder="yourname or you@example.com" />
+            </div>
+
+            <div class="account-field">
+              <label for="account-signin-password">Password <span aria-hidden="true">*</span></label>
+              <input id="account-signin-password" name="password" type="password" minlength="8" maxlength="64" autocomplete="current-password" required placeholder="Your password" />
+            </div>
+
+            <p id="account-signin-error" class="account-error" role="alert" hidden></p>
+            <p id="account-signin-success" class="account-success" role="status" hidden></p>
+            <button type="submit" class="btn btn-primary">Sign in</button>
+          </form>
+
+          <p id="account-active-status" class="account-active-status" aria-live="polite">Not signed in.</p>
+          <button type="button" id="account-signout" class="btn" hidden>Sign out</button>
+
+          <p class="account-hint">Need to start posting? Head back to the <a href="/forums/">community forum</a>.</p>
+        </div>
+      </article>
+    </section>
+  </main>
+
+  <div data-include="/partials/footer.html"></div>
+</body>
+</html>

--- a/assets/account.js
+++ b/assets/account.js
@@ -1,0 +1,352 @@
+(function(){
+  const ROOT = document.getElementById('account-root');
+  if(!ROOT){
+    return;
+  }
+
+  const ACCOUNT_STORAGE_KEY = 'extynct-accounts';
+  const LEGACY_ACCOUNT_STORAGE_KEY = 'extynct-forum-accounts';
+  const ACTIVE_ACCOUNT_KEY = 'extynct-active-account';
+
+  const createForm = document.getElementById('account-create-form');
+  const createErrorEl = document.getElementById('account-create-error');
+  const createSuccessEl = document.getElementById('account-create-success');
+  const signInForm = document.getElementById('account-signin-form');
+  const signInErrorEl = document.getElementById('account-signin-error');
+  const signInSuccessEl = document.getElementById('account-signin-success');
+  const activeStatusEl = document.getElementById('account-active-status');
+  const signOutButton = document.getElementById('account-signout');
+
+  let storageAvailable = true;
+  let accounts = [];
+  let activeAccountId = null;
+
+  function safeCall(fn){
+    if(!storageAvailable){
+      return null;
+    }
+    try{
+      return fn();
+    }catch(err){
+      console.warn('Account storage unavailable:', err);
+      storageAvailable = false;
+      return null;
+    }
+  }
+
+  function clearLegacyStorage(){
+    safeCall(() => localStorage.removeItem(LEGACY_ACCOUNT_STORAGE_KEY));
+  }
+
+  function readAccounts(){
+    const raw = safeCall(() => localStorage.getItem(ACCOUNT_STORAGE_KEY));
+    if(!raw){
+      return [];
+    }
+
+    try{
+      const parsed = JSON.parse(raw);
+      if(Array.isArray(parsed)){
+        return parsed;
+      }
+    }catch(err){
+      console.warn('Failed to parse saved accounts', err);
+    }
+    return [];
+  }
+
+  function saveAccounts(list){
+    if(!Array.isArray(list)){
+      return;
+    }
+    safeCall(() => localStorage.setItem(ACCOUNT_STORAGE_KEY, JSON.stringify(list)));
+  }
+
+  function readActiveAccountId(){
+    return safeCall(() => localStorage.getItem(ACTIVE_ACCOUNT_KEY));
+  }
+
+  function saveActiveAccountId(id){
+    if(id){
+      safeCall(() => localStorage.setItem(ACTIVE_ACCOUNT_KEY, id));
+    }else{
+      safeCall(() => localStorage.removeItem(ACTIVE_ACCOUNT_KEY));
+    }
+  }
+
+  async function hashPassword(password){
+    if(typeof password !== 'string'){
+      return '';
+    }
+
+    if(typeof crypto !== 'undefined' && crypto.subtle && typeof TextEncoder !== 'undefined'){
+      const encoder = new TextEncoder();
+      const data = encoder.encode(password);
+      const digest = await crypto.subtle.digest('SHA-256', data);
+      const bytes = Array.from(new Uint8Array(digest));
+      return bytes.map((byte) => byte.toString(16).padStart(2, '0')).join('');
+    }
+
+    try{
+      return btoa(unescape(encodeURIComponent(password)));
+    }catch(err){
+      return password;
+    }
+  }
+
+  function clearCreateMessages(){
+    if(createErrorEl){
+      createErrorEl.hidden = true;
+      createErrorEl.textContent = '';
+    }
+    if(createSuccessEl){
+      createSuccessEl.hidden = true;
+      createSuccessEl.textContent = '';
+    }
+  }
+
+  function clearSignInMessages(){
+    if(signInErrorEl){
+      signInErrorEl.hidden = true;
+      signInErrorEl.textContent = '';
+    }
+    if(signInSuccessEl){
+      signInSuccessEl.hidden = true;
+      signInSuccessEl.textContent = '';
+    }
+  }
+
+  function showCreateError(message){
+    if(createErrorEl){
+      createErrorEl.textContent = message;
+      createErrorEl.hidden = false;
+    }
+    if(createSuccessEl){
+      createSuccessEl.hidden = true;
+      createSuccessEl.textContent = '';
+    }
+  }
+
+  function showCreateSuccess(message){
+    if(createSuccessEl){
+      createSuccessEl.textContent = message;
+      createSuccessEl.hidden = false;
+    }
+    if(createErrorEl){
+      createErrorEl.hidden = true;
+      createErrorEl.textContent = '';
+    }
+  }
+
+  function showSignInError(message){
+    if(signInErrorEl){
+      signInErrorEl.textContent = message;
+      signInErrorEl.hidden = false;
+    }
+    if(signInSuccessEl){
+      signInSuccessEl.hidden = true;
+      signInSuccessEl.textContent = '';
+    }
+  }
+
+  function showSignInSuccess(message){
+    if(signInSuccessEl){
+      signInSuccessEl.textContent = message;
+      signInSuccessEl.hidden = false;
+    }
+    if(signInErrorEl){
+      signInErrorEl.hidden = true;
+      signInErrorEl.textContent = '';
+    }
+  }
+
+  function createId(prefix = 'acct'){
+    if(typeof crypto !== 'undefined' && crypto.randomUUID){
+      const uuid = crypto.randomUUID();
+      return prefix ? `${prefix}-${uuid}` : uuid;
+    }
+    const fallback = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    return prefix ? `${prefix}-${fallback}` : fallback;
+  }
+
+  function getActiveAccount(){
+    if(!activeAccountId){
+      return null;
+    }
+    return accounts.find((acct) => acct && acct.id === activeAccountId) || null;
+  }
+
+  function updateActiveStatus(message){
+    const activeAccount = getActiveAccount();
+    if(activeStatusEl){
+      if(activeAccount){
+        activeStatusEl.textContent = message || `Signed in as @${activeAccount.username}`;
+      }else{
+        activeStatusEl.textContent = message || 'Not signed in.';
+      }
+    }
+    if(signOutButton){
+      signOutButton.hidden = !activeAccount;
+    }
+  }
+
+  function setActiveAccount(id, message){
+    activeAccountId = id || null;
+    saveActiveAccountId(activeAccountId);
+    updateActiveStatus(message);
+  }
+
+  function ensureStorage(){
+    if(storageAvailable){
+      return true;
+    }
+    showCreateError('Local storage is disabled, so accounts cannot be saved on this device.');
+    showSignInError('Local storage is disabled, so sign-in is unavailable.');
+    return false;
+  }
+
+  clearLegacyStorage();
+  accounts = readAccounts();
+  activeAccountId = readActiveAccountId();
+  updateActiveStatus();
+
+  if(createForm){
+    createForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      clearCreateMessages();
+
+      if(!ensureStorage()){
+        return;
+      }
+
+      const formData = new FormData(createForm);
+      const usernameRaw = (formData.get('username') || '').toString().trim();
+      const emailRaw = (formData.get('email') || '').toString().trim();
+      const password = (formData.get('password') || '').toString();
+      const confirm = (formData.get('confirm') || '').toString();
+
+      if(!usernameRaw){
+        showCreateError('Please choose a username.');
+        return;
+      }
+      if(!emailRaw){
+        showCreateError('Please add an email.');
+        return;
+      }
+      if(password.length < 8){
+        showCreateError('Passwords must be at least 8 characters long.');
+        return;
+      }
+      if(password !== confirm){
+        showCreateError('Passwords do not match.');
+        return;
+      }
+
+      const usernamePattern = /^[a-zA-Z0-9_\-]{3,32}$/;
+      if(!usernamePattern.test(usernameRaw)){
+        showCreateError('Usernames must be 3-32 characters and can use letters, numbers, underscores, or hyphens.');
+        return;
+      }
+
+      const normalizedEmail = emailRaw.toLowerCase();
+      const normalizedUsername = usernameRaw.toLowerCase();
+
+      if(accounts.some((acct) => acct.username && acct.username.toLowerCase() === normalizedUsername)){
+        showCreateError('That username is already in use on this device.');
+        return;
+      }
+
+      if(accounts.some((acct) => acct.email === normalizedEmail)){
+        showCreateError('That email is already linked to an account on this device.');
+        return;
+      }
+
+      try{
+        const passwordHash = await hashPassword(password);
+        const account = {
+          id: createId('acct'),
+          username: usernameRaw,
+          email: normalizedEmail,
+          passwordHash,
+          createdAt: new Date().toISOString()
+        };
+
+        accounts.push(account);
+        saveAccounts(accounts);
+
+        if(!storageAvailable){
+          accounts.pop();
+          showCreateError('Local storage is disabled, so accounts cannot be saved on this device.');
+          return;
+        }
+
+        createForm.reset();
+        showCreateSuccess(`Account @${account.username} created. You're signed in!`);
+        setActiveAccount(account.id);
+      }catch(err){
+        console.error('Failed to create account', err);
+        showCreateError('Something went wrong while saving your account. Please try again.');
+      }
+    });
+  }
+
+  if(signInForm){
+    signInForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      clearSignInMessages();
+
+      if(!ensureStorage()){
+        return;
+      }
+
+      const formData = new FormData(signInForm);
+      const identifierRaw = (formData.get('identifier') || '').toString().trim();
+      const password = (formData.get('password') || '').toString();
+
+      if(!identifierRaw){
+        showSignInError('Enter the email or username connected to your account.');
+        return;
+      }
+      if(password.length === 0){
+        showSignInError('Enter your password to sign in.');
+        return;
+      }
+
+      const normalizedIdentifier = identifierRaw.toLowerCase();
+      const match = accounts.find((acct) => {
+        if(!acct){
+          return false;
+        }
+        return acct.email === normalizedIdentifier || (acct.username && acct.username.toLowerCase() === normalizedIdentifier);
+      });
+
+      if(!match){
+        showSignInError('We could not find an account with that email or username.');
+        return;
+      }
+
+      try{
+        const passwordHash = await hashPassword(password);
+        if(match.passwordHash !== passwordHash){
+          showSignInError('Incorrect password.');
+          return;
+        }
+
+        setActiveAccount(match.id, `Signed in as @${match.username}.`);
+        showSignInSuccess(`Welcome back, @${match.username}!`);
+        signInForm.reset();
+      }catch(err){
+        console.error('Failed to sign in', err);
+        showSignInError('Something went wrong while signing you in. Please try again.');
+      }
+    });
+  }
+
+  if(signOutButton){
+    signOutButton.addEventListener('click', () => {
+      clearSignInMessages();
+      setActiveAccount(null, 'Signed out.');
+      showSignInSuccess('Signed out.');
+    });
+  }
+})();

--- a/assets/forum.js
+++ b/assets/forum.js
@@ -1,0 +1,411 @@
+(function(){
+  const ROOT = document.getElementById('forum-root');
+  if(!ROOT){
+    return;
+  }
+
+  const STORAGE_KEY = 'extynct-forum-posts';
+  const form = document.getElementById('forum-form');
+  const postsContainer = document.getElementById('forum-posts');
+  const emptyState = document.getElementById('forum-empty');
+  const errorEl = document.getElementById('forum-form-error');
+  const storageWarning = document.getElementById('forum-storage-warning');
+  const resetButton = document.getElementById('forum-reset');
+
+  if(!form || !postsContainer || !emptyState || !resetButton){
+    return;
+  }
+
+  let storageAvailable = true;
+
+  function safeCall(fn){
+    if(!storageAvailable){
+      return null;
+    }
+
+    try{
+      return fn();
+    }catch(err){
+      console.warn('Forum storage unavailable:', err);
+      storageAvailable = false;
+      if(storageWarning){
+        storageWarning.hidden = false;
+      }
+      return null;
+    }
+  }
+
+  function readStoredPosts(){
+    const value = safeCall(() => localStorage.getItem(STORAGE_KEY));
+    if(!value){
+      return null;
+    }
+
+    try{
+      const parsed = JSON.parse(value);
+      if(Array.isArray(parsed)){
+        return parsed;
+      }
+    }catch(err){
+      console.warn('Unable to parse stored forum data', err);
+    }
+    return null;
+  }
+
+  function savePosts(posts){
+    safeCall(() => localStorage.setItem(STORAGE_KEY, JSON.stringify(posts)));
+  }
+
+  function createDemoPosts(){
+    const now = new Date();
+    const iso = (offsetHours) => new Date(now.getTime() - offsetHours * 3600 * 1000).toISOString();
+    return [
+      {
+        id: 'demo-1',
+        title: 'Show us your best Turn & Burn drift!',
+        body: 'Drop a clip of your cleanest drift lines or photo-finish wins. Bonus points for camera shake and neon trails.',
+        author: 'ExtynctMod',
+        category: 'Showcase',
+        createdAt: iso(18),
+        media: [
+          {
+            type: 'image',
+            src: '/assets/images/turnandburn/header.jpg'
+          }
+        ]
+      },
+      {
+        id: 'demo-2',
+        title: 'IonCore alpha build feedback thread',
+        body: 'We pushed a patch with new dash timing. Let us know how it feels and if the cooldown creates any weird loops.',
+        author: 'GearboundDev',
+        category: 'Feedback',
+        createdAt: iso(36),
+        media: [
+          {
+            type: 'video',
+            src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4'
+          }
+        ]
+      },
+      {
+        id: 'demo-3',
+        title: 'Fan art: WarpGate sunset concept',
+        body: 'Tried pushing the color palette into warmer territory while keeping the synthwave skyline vibe. Thoughts?',
+        author: 'NovaRacer',
+        category: 'General',
+        createdAt: iso(60),
+        media: [
+          {
+            type: 'image',
+            src: '/assets/images/warpgate/header.jpg'
+          }
+        ]
+      }
+    ];
+  }
+
+  function formatDate(value){
+    try{
+      return new Date(value).toLocaleString([], {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    }catch(err){
+      return value;
+    }
+  }
+
+  function createId(){
+    if(typeof crypto !== 'undefined' && crypto.randomUUID){
+      return crypto.randomUUID();
+    }
+    return `post-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }
+
+  function parseMediaLink(value){
+    if(!value){
+      return null;
+    }
+    let parsed;
+    try{
+      parsed = new URL(value);
+    }catch(err){
+      return null;
+    }
+
+    const pathname = parsed.pathname.toLowerCase();
+    const ext = pathname.split('.').pop();
+    const imageExt = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'];
+    const videoExt = ['mp4', 'webm', 'ogg', 'mov'];
+
+    if(imageExt.includes(ext)){
+      return { type: 'image', src: parsed.href };
+    }
+    if(videoExt.includes(ext)){
+      return { type: 'video', src: parsed.href };
+    }
+
+    if(parsed.hostname.includes('youtube.com') || parsed.hostname.includes('youtu.be')){
+      const videoId = parsed.searchParams.get('v') || pathname.replace('/', '');
+      if(videoId){
+        return {
+          type: 'embed',
+          provider: 'youtube',
+          src: `https://www.youtube.com/embed/${videoId}`
+        };
+      }
+    }
+
+    return {
+      type: 'link',
+      src: parsed.href
+    };
+  }
+
+  function readFileAsDataUrl(file){
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error || new Error('Failed to read file'));
+      reader.readAsDataURL(file);
+    });
+  }
+
+  async function extractMedia(fileInput, linkInput){
+    const file = fileInput && fileInput.files ? fileInput.files[0] : null;
+    const link = linkInput ? linkInput.value.trim() : '';
+
+    if(file){
+      const isImage = file.type.startsWith('image/');
+      const isVideo = file.type.startsWith('video/');
+      const maxImageSize = 5 * 1024 * 1024;
+      const maxVideoSize = 20 * 1024 * 1024;
+
+      if(isImage && file.size > maxImageSize){
+        throw new Error('Images must be 5 MB or smaller.');
+      }
+      if(isVideo && file.size > maxVideoSize){
+        throw new Error('Videos must be 20 MB or smaller.');
+      }
+
+      const dataUrl = await readFileAsDataUrl(file);
+      return [
+        {
+          type: isVideo ? 'video' : 'image',
+          src: dataUrl,
+          name: file.name
+        }
+      ];
+    }
+
+    const parsed = parseMediaLink(link);
+    if(parsed){
+      return [parsed];
+    }
+
+    return [];
+  }
+
+  function renderBody(body){
+    const container = document.createElement('div');
+    const paragraphs = body.split(/\n{2,}/).filter(Boolean);
+
+    if(paragraphs.length === 0){
+      const line = document.createElement('p');
+      line.textContent = body.trim();
+      container.appendChild(line);
+      return container;
+    }
+
+    paragraphs.forEach((chunk) => {
+      const p = document.createElement('p');
+      p.textContent = chunk.trim();
+      container.appendChild(p);
+    });
+
+    return container;
+  }
+
+  function renderMedia(media){
+    const wrapper = document.createElement('div');
+    wrapper.className = 'forum-media-group';
+
+    media.forEach((item) => {
+      const mediaContainer = document.createElement('div');
+      mediaContainer.className = 'forum-media';
+
+      if(item.type === 'image'){
+        const img = document.createElement('img');
+        img.src = item.src;
+        img.alt = item.name ? `${item.name} attachment` : 'Post attachment';
+        img.loading = 'lazy';
+        mediaContainer.appendChild(img);
+      }else if(item.type === 'video'){
+        const video = document.createElement('video');
+        video.controls = true;
+        video.src = item.src;
+        video.preload = 'metadata';
+        mediaContainer.appendChild(video);
+      }else if(item.type === 'embed' && item.provider === 'youtube'){
+        const iframe = document.createElement('iframe');
+        iframe.src = item.src;
+        iframe.width = '560';
+        iframe.height = '315';
+        iframe.loading = 'lazy';
+        iframe.allowFullscreen = true;
+        iframe.setAttribute('title', 'Embedded video');
+        mediaContainer.appendChild(iframe);
+      }else if(item.type === 'link'){
+        const link = document.createElement('a');
+        link.href = item.src;
+        link.target = '_blank';
+        link.rel = 'noopener';
+        link.className = 'forum-media-link';
+        link.textContent = 'Open attached link';
+        mediaContainer.appendChild(link);
+      }
+
+      wrapper.appendChild(mediaContainer);
+    });
+
+    return wrapper;
+  }
+
+  function renderPosts(posts){
+    postsContainer.innerHTML = '';
+    if(!posts || posts.length === 0){
+      emptyState.hidden = false;
+      return;
+    }
+
+    emptyState.hidden = true;
+
+    const sorted = [...posts].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+    sorted.forEach((post) => {
+      const article = document.createElement('article');
+      article.className = 'card forum-thread';
+      article.setAttribute('data-post-id', post.id);
+
+      const body = document.createElement('div');
+      body.className = 'card-body forum-thread-body';
+
+      const header = document.createElement('header');
+      header.className = 'forum-thread-header';
+
+      const title = document.createElement('h3');
+      title.className = 'forum-thread-title';
+      title.textContent = post.title;
+
+      const meta = document.createElement('div');
+      meta.className = 'forum-thread-meta';
+
+      const pill = document.createElement('span');
+      pill.className = 'forum-pill';
+      pill.textContent = post.category || 'General';
+
+      const author = document.createElement('span');
+      author.className = 'forum-thread-author';
+      author.textContent = post.author ? `@${post.author}` : 'Anonymous player';
+
+      const date = document.createElement('time');
+      date.dateTime = post.createdAt;
+      date.textContent = formatDate(post.createdAt);
+
+      meta.appendChild(pill);
+      meta.appendChild(author);
+      meta.appendChild(date);
+
+      header.appendChild(title);
+      header.appendChild(meta);
+
+      body.appendChild(header);
+      body.appendChild(renderBody(post.body));
+
+      if(post.media && post.media.length > 0){
+        body.appendChild(renderMedia(post.media));
+      }
+
+      article.appendChild(body);
+      postsContainer.appendChild(article);
+    });
+  }
+
+  function clearForm(){
+    form.reset();
+  }
+
+  function showError(message){
+    if(!errorEl){
+      return;
+    }
+    errorEl.textContent = message;
+    errorEl.hidden = false;
+  }
+
+  function clearError(){
+    if(!errorEl){
+      return;
+    }
+    errorEl.hidden = true;
+    errorEl.textContent = '';
+  }
+
+  let posts = readStoredPosts();
+  if(!posts){
+    posts = createDemoPosts();
+    savePosts(posts);
+  }
+  renderPosts(posts);
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearError();
+
+    const formData = new FormData(form);
+    const title = (formData.get('title') || '').toString().trim();
+    const bodyValue = (formData.get('body') || '').toString().trim();
+
+    if(!title){
+      showError('Please add a title before posting.');
+      return;
+    }
+    if(!bodyValue){
+      showError('Please share a bit more detail so people can help.');
+      return;
+    }
+
+    try{
+      const media = await extractMedia(
+        document.getElementById('forum-media-file'),
+        document.getElementById('forum-media-link')
+      );
+
+      const newPost = {
+        id: createId(),
+        title,
+        body: bodyValue,
+        author: (formData.get('author') || '').toString().trim(),
+        category: (formData.get('category') || 'General').toString(),
+        createdAt: new Date().toISOString(),
+        media
+      };
+
+      posts.push(newPost);
+      savePosts(posts);
+      renderPosts(posts);
+      clearForm();
+    }catch(err){
+      showError(err.message || 'Something went wrong while attaching your media.');
+    }
+  });
+
+  resetButton.addEventListener('click', () => {
+    posts = createDemoPosts();
+    savePosts(posts);
+    renderPosts(posts);
+  });
+})();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -146,36 +146,33 @@ body{
 
 /* FORUM */
 .forum-subtitle{color:#475569;margin:1rem 0 0;max-width:60ch}
+.forum-hero-action{margin-top:1.5rem}
 .forum-layout{display:grid;gap:2rem;align-items:flex-start;margin-bottom:3rem;grid-template-columns:minmax(0,1.65fr)minmax(0,.95fr)}
 .forum-main{display:flex;flex-direction:column;gap:1.75rem}
 .forum-form-title{margin:0;font:700 1.2rem/1.25 system-ui}
 .forum-storage-note{color:#475569;margin:.5rem 0 1.25rem;font-size:.95rem}
-.forum-account-card .card-body{display:grid;gap:1.5rem}
-.forum-account-title{margin:0;font:700 1.2rem/1.25 system-ui}
-.forum-account-intro{margin:0;color:#475569;font-size:.95rem}
-.forum-account-form{display:grid;gap:1rem}
-.forum-account-manage{display:grid;gap:.85rem;padding:1.1rem;border:2px dashed rgba(15,23,42,.15);border-radius:1rem;background:#f8fafc}
-.forum-account-status{margin:0;font:700 1rem/1.2 system-ui;color:#0f172a}
-.forum-account-select select{width:100%;padding:.65rem .85rem;border:2px solid rgba(15,23,42,.15);border-radius:.85rem;background:#fff;font:500 .95rem/1.4 system-ui;color:#0f172a;transition:border-color .2s,box-shadow .2s,background .2s}
-.forum-account-select select:focus{outline:none;border-color:#0284c7;box-shadow:0 0 0 3px rgba(56,189,248,0.25);background:#f8fafc}
-.forum-account-signout{justify-self:start}
+.forum-session-card .card-body{display:grid;gap:1rem}
+.forum-session-title{margin:0;font:700 1.1rem/1.25 system-ui}
+.forum-session-status{margin:0;color:#1e293b;font-weight:600}
+.forum-session-actions{display:flex;flex-wrap:wrap;gap:.75rem}
+.forum-session-actions .btn{flex:0 0 auto}
 .forum-success{margin:0;color:#047857;font-weight:600}
 .forum-form{display:grid;gap:1.25rem}
 .forum-field{display:flex;flex-direction:column;gap:.5rem}
-.forum-form label,.forum-form legend,.forum-account-form label{font:600 .95rem/1.2 system-ui;color:#0f172a}
-.forum-form input,.forum-form textarea,.forum-form select,.forum-account-form input{width:100%;padding:.65rem .85rem;border:2px solid rgba(15,23,42,.15);border-radius:.85rem;background:#fff;font:500 .95rem/1.4 system-ui;color:#0f172a;transition:border-color .2s,box-shadow .2s,background .2s}
-.forum-form input:focus,.forum-form textarea:focus,.forum-form select:focus,.forum-account-form input:focus{outline:none;border-color:#0284c7;box-shadow:0 0 0 3px rgba(56,189,248,0.25);background:#f8fafc}
+.forum-form label,.forum-form legend,.account-form label{font:600 .95rem/1.2 system-ui;color:#0f172a}
+.forum-form input,.forum-form textarea,.forum-form select,.account-form input{width:100%;padding:.65rem .85rem;border:2px solid rgba(15,23,42,.15);border-radius:.85rem;background:#fff;font:500 .95rem/1.4 system-ui;color:#0f172a;transition:border-color .2s,box-shadow .2s,background .2s}
+.forum-form input:focus,.forum-form textarea:focus,.forum-form select:focus,.account-form input:focus{outline:none;border-color:#0284c7;box-shadow:0 0 0 3px rgba(56,189,248,0.25);background:#f8fafc}
 .forum-form textarea{min-height:8rem;resize:vertical}
 .forum-form fieldset{border:2px dashed rgba(15,23,42,.2);padding:1rem 1.25rem;border-radius:1rem}
 .forum-field-help{margin:-.25rem 0 .5rem;color:#475569;font-size:.9rem}
 .forum-sublabel{font:600 .85rem/1.2 system-ui;color:#1e293b}
 .forum-error{margin:0;color:#dc2626;font-weight:600}
 .forum-warning{margin:0;color:#b45309;font-weight:600}
+.forum-locked{margin:0;color:#b45309;font-weight:600}
 .forum-submit{align-self:flex-start}
+.forum-form-disabled{opacity:.6}
 .forum-threads{display:flex;flex-direction:column;gap:1.5rem}
 .forum-threads-header{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.75rem}
-.forum-reset{background:#f8fafc;color:#0f172a;border-color:rgba(15,23,42,.15)}
-.forum-reset-hint{margin:-1rem 0 0;color:#64748b;font-size:.85rem}
 .forum-empty{margin:0;padding:2.5rem 0;text-align:center;color:#64748b;font-style:italic}
 .forum-thread-list{display:grid;gap:1.5rem}
 .forum-thread-title{margin:0;font:700 1.15rem/1.25 system-ui}
@@ -198,9 +195,28 @@ body{
 .forum-links a{text-decoration:none;color:#0f172a;font-weight:600}
 .forum-links a:hover{text-decoration:underline}
 
+/* ACCOUNT */
+.account-subtitle{color:#475569;margin:1rem 0 0;max-width:60ch}
+.account-layout{display:grid;gap:2rem;align-items:flex-start;margin-bottom:3rem;grid-template-columns:repeat(2,minmax(0,1fr))}
+.account-card .card-body{display:grid;gap:1.25rem}
+.account-card-title{margin:0;font:700 1.1rem/1.25 system-ui}
+.account-card-intro{margin:0;color:#475569;font-size:.95rem}
+.account-form{display:grid;gap:1rem}
+.account-field{display:flex;flex-direction:column;gap:.5rem}
+.account-error{margin:0;color:#dc2626;font-weight:600}
+.account-success{margin:0;color:#047857;font-weight:600}
+.account-active-status{margin:1rem 0 0;font:600 1rem/1.3 system-ui;color:#0f172a}
+.account-hint{margin:1rem 0 0;color:#475569;font-size:.95rem}
+.account-hint a{font-weight:600;color:#0f172a;text-decoration:none}
+.account-hint a:hover{text-decoration:underline}
+
 @media (max-width:1024px){
   .forum-layout{grid-template-columns:1fr}
   .forum-sidebar{order:-1}
+}
+
+@media (max-width:900px){
+  .account-layout{grid-template-columns:1fr}
 }
 
 @media (max-width:640px){
@@ -222,17 +238,18 @@ body{
     0 4px 8px rgba(0,0,0,0.6),
     0 0 0 3px rgba(56,189,248,0.2);
 }
-.dark .forum-subtitle,.dark .forum-storage-note,.dark .forum-reset-hint,.dark .forum-thread-meta,.dark .forum-guidelines,.dark .forum-links{color:#cbd5f5}
+.dark .forum-subtitle,.dark .forum-session-status,.dark .forum-storage-note,.dark .forum-thread-meta,.dark .forum-guidelines,.dark .forum-links,.dark .account-subtitle,.dark .account-hint{color:#cbd5f5}
 .dark .forum-form label,.dark .forum-form legend{color:#e2e8f0}
-.dark .forum-form input,.dark .forum-form textarea,.dark .forum-form select{background:#0f172a;color:#e2e8f0;border-color:rgba(148,163,184,0.4)}
-.dark .forum-form input:focus,.dark .forum-form textarea:focus,.dark .forum-form select:focus{background:#111c2f;border-color:#38bdf8}
+.dark .forum-form input,.dark .forum-form textarea,.dark .forum-form select,.dark .account-form input{background:#0f172a;color:#e2e8f0;border-color:rgba(148,163,184,0.4)}
+.dark .forum-form input:focus,.dark .forum-form textarea:focus,.dark .forum-form select:focus,.dark .account-form input:focus{background:#111c2f;border-color:#38bdf8}
 .dark .forum-form fieldset{border-color:rgba(148,163,184,0.35)}
-.dark .forum-sublabel{color:#e2e8f0}
-.dark .forum-error{color:#fca5a5}
-.dark .forum-warning{color:#fcd34d}
+.dark .forum-sublabel,.dark .account-card-intro{color:#e2e8f0}
+.dark .forum-error,.dark .account-error{color:#fca5a5}
+.dark .forum-warning,.dark .forum-locked{color:#fcd34d}
 .dark .forum-pill{background:rgba(56,189,248,0.2);color:#bae6fd}
 .dark .forum-media-link{color:#bae6fd}
-.dark .forum-links a{color:#bae6fd}
+.dark .forum-links a,.dark .account-hint a{color:#bae6fd}
+.dark .account-active-status{color:#e2e8f0}
 .dark .card:hover{
   border-color:rgba(56,189,248,0.5);
   box-shadow:

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -150,11 +150,21 @@ body{
 .forum-main{display:flex;flex-direction:column;gap:1.75rem}
 .forum-form-title{margin:0;font:700 1.2rem/1.25 system-ui}
 .forum-storage-note{color:#475569;margin:.5rem 0 1.25rem;font-size:.95rem}
+.forum-account-card .card-body{display:grid;gap:1.5rem}
+.forum-account-title{margin:0;font:700 1.2rem/1.25 system-ui}
+.forum-account-intro{margin:0;color:#475569;font-size:.95rem}
+.forum-account-form{display:grid;gap:1rem}
+.forum-account-manage{display:grid;gap:.85rem;padding:1.1rem;border:2px dashed rgba(15,23,42,.15);border-radius:1rem;background:#f8fafc}
+.forum-account-status{margin:0;font:700 1rem/1.2 system-ui;color:#0f172a}
+.forum-account-select select{width:100%;padding:.65rem .85rem;border:2px solid rgba(15,23,42,.15);border-radius:.85rem;background:#fff;font:500 .95rem/1.4 system-ui;color:#0f172a;transition:border-color .2s,box-shadow .2s,background .2s}
+.forum-account-select select:focus{outline:none;border-color:#0284c7;box-shadow:0 0 0 3px rgba(56,189,248,0.25);background:#f8fafc}
+.forum-account-signout{justify-self:start}
+.forum-success{margin:0;color:#047857;font-weight:600}
 .forum-form{display:grid;gap:1.25rem}
 .forum-field{display:flex;flex-direction:column;gap:.5rem}
-.forum-form label,.forum-form legend{font:600 .95rem/1.2 system-ui;color:#0f172a}
-.forum-form input,.forum-form textarea,.forum-form select{width:100%;padding:.65rem .85rem;border:2px solid rgba(15,23,42,.15);border-radius:.85rem;background:#fff;font:500 .95rem/1.4 system-ui;color:#0f172a;transition:border-color .2s,box-shadow .2s,background .2s}
-.forum-form input:focus,.forum-form textarea:focus,.forum-form select:focus{outline:none;border-color:#0284c7;box-shadow:0 0 0 3px rgba(56,189,248,0.25);background:#f8fafc}
+.forum-form label,.forum-form legend,.forum-account-form label{font:600 .95rem/1.2 system-ui;color:#0f172a}
+.forum-form input,.forum-form textarea,.forum-form select,.forum-account-form input{width:100%;padding:.65rem .85rem;border:2px solid rgba(15,23,42,.15);border-radius:.85rem;background:#fff;font:500 .95rem/1.4 system-ui;color:#0f172a;transition:border-color .2s,box-shadow .2s,background .2s}
+.forum-form input:focus,.forum-form textarea:focus,.forum-form select:focus,.forum-account-form input:focus{outline:none;border-color:#0284c7;box-shadow:0 0 0 3px rgba(56,189,248,0.25);background:#f8fafc}
 .forum-form textarea{min-height:8rem;resize:vertical}
 .forum-form fieldset{border:2px dashed rgba(15,23,42,.2);padding:1rem 1.25rem;border-radius:1rem}
 .forum-field-help{margin:-.25rem 0 .5rem;color:#475569;font-size:.9rem}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -144,6 +144,60 @@ body{
 .mb-2{margin-bottom:.5rem}.mb-3{margin-bottom:.75rem}.mb-4{margin-bottom:1rem}.mb-6{margin-bottom:1.5rem}.mb-8{margin-bottom:2rem}
 .flex{display:flex}.items-center{align-items:center}.justify-between{justify-content:space-between}.gap-2{gap:.5rem}.gap-3{gap:.75rem}.gap-4{gap:1rem}
 
+/* FORUM */
+.forum-subtitle{color:#475569;margin:1rem 0 0;max-width:60ch}
+.forum-layout{display:grid;gap:2rem;align-items:flex-start;margin-bottom:3rem;grid-template-columns:minmax(0,1.65fr)minmax(0,.95fr)}
+.forum-main{display:flex;flex-direction:column;gap:1.75rem}
+.forum-form-title{margin:0;font:700 1.2rem/1.25 system-ui}
+.forum-storage-note{color:#475569;margin:.5rem 0 1.25rem;font-size:.95rem}
+.forum-form{display:grid;gap:1.25rem}
+.forum-field{display:flex;flex-direction:column;gap:.5rem}
+.forum-form label,.forum-form legend{font:600 .95rem/1.2 system-ui;color:#0f172a}
+.forum-form input,.forum-form textarea,.forum-form select{width:100%;padding:.65rem .85rem;border:2px solid rgba(15,23,42,.15);border-radius:.85rem;background:#fff;font:500 .95rem/1.4 system-ui;color:#0f172a;transition:border-color .2s,box-shadow .2s,background .2s}
+.forum-form input:focus,.forum-form textarea:focus,.forum-form select:focus{outline:none;border-color:#0284c7;box-shadow:0 0 0 3px rgba(56,189,248,0.25);background:#f8fafc}
+.forum-form textarea{min-height:8rem;resize:vertical}
+.forum-form fieldset{border:2px dashed rgba(15,23,42,.2);padding:1rem 1.25rem;border-radius:1rem}
+.forum-field-help{margin:-.25rem 0 .5rem;color:#475569;font-size:.9rem}
+.forum-sublabel{font:600 .85rem/1.2 system-ui;color:#1e293b}
+.forum-error{margin:0;color:#dc2626;font-weight:600}
+.forum-warning{margin:0;color:#b45309;font-weight:600}
+.forum-submit{align-self:flex-start}
+.forum-threads{display:flex;flex-direction:column;gap:1.5rem}
+.forum-threads-header{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.75rem}
+.forum-reset{background:#f8fafc;color:#0f172a;border-color:rgba(15,23,42,.15)}
+.forum-reset-hint{margin:-1rem 0 0;color:#64748b;font-size:.85rem}
+.forum-empty{margin:0;padding:2.5rem 0;text-align:center;color:#64748b;font-style:italic}
+.forum-thread-list{display:grid;gap:1.5rem}
+.forum-thread-title{margin:0;font:700 1.15rem/1.25 system-ui}
+.forum-thread-meta{display:flex;flex-wrap:wrap;align-items:center;gap:.75rem;margin-top:.5rem;color:#475569;font:500 .85rem/1.2 system-ui}
+.forum-thread-author::before{content:'•';margin:0 .4rem}
+.forum-thread-body p{margin:.85rem 0 0;color:#1f2937}
+.forum-thread-body p:first-of-type{margin-top:.75rem}
+.forum-pill{display:inline-flex;align-items:center;padding:.25rem .65rem;border-radius:999px;background:#e0f2fe;color:#0369a1;font:700 .75rem/1 system-ui;text-transform:uppercase;letter-spacing:.02em}
+.forum-media-group{display:grid;gap:1rem;margin-top:1rem}
+.forum-media{border-radius:1rem;overflow:hidden;box-shadow:0 3px 12px rgba(15,23,42,0.15)}
+.forum-media img,.forum-media video,.forum-media iframe{width:100%;display:block;background:#000}
+.forum-media video,.forum-media iframe{aspect-ratio:16/9}
+.forum-media iframe{border:0}
+.forum-media-link{display:inline-block;padding:1rem;text-decoration:none;color:#0f172a;font-weight:600}
+.forum-media-link:hover{text-decoration:underline}
+.forum-sidebar{display:flex;flex-direction:column;gap:1.5rem}
+.forum-sidebar-title{margin:0;font:700 1.05rem/1.2 system-ui}
+.forum-guidelines,.forum-links{margin:1rem 0 0;padding-left:1.1rem;color:#475569;display:grid;gap:.5rem;font-size:.95rem}
+.forum-links{list-style:none;padding-left:0}
+.forum-links a{text-decoration:none;color:#0f172a;font-weight:600}
+.forum-links a:hover{text-decoration:underline}
+
+@media (max-width:1024px){
+  .forum-layout{grid-template-columns:1fr}
+  .forum-sidebar{order:-1}
+}
+
+@media (max-width:640px){
+  .forum-form fieldset{padding:1rem}
+  .forum-media video,.forum-media iframe{aspect-ratio:4/3}
+}
+
 /* DARK MODE */
 .dark body{background:#0b1220;color:#e5e7eb}
 .dark .navbar{
@@ -158,6 +212,17 @@ body{
     0 4px 8px rgba(0,0,0,0.6),
     0 0 0 3px rgba(56,189,248,0.2);
 }
+.dark .forum-subtitle,.dark .forum-storage-note,.dark .forum-reset-hint,.dark .forum-thread-meta,.dark .forum-guidelines,.dark .forum-links{color:#cbd5f5}
+.dark .forum-form label,.dark .forum-form legend{color:#e2e8f0}
+.dark .forum-form input,.dark .forum-form textarea,.dark .forum-form select{background:#0f172a;color:#e2e8f0;border-color:rgba(148,163,184,0.4)}
+.dark .forum-form input:focus,.dark .forum-form textarea:focus,.dark .forum-form select:focus{background:#111c2f;border-color:#38bdf8}
+.dark .forum-form fieldset{border-color:rgba(148,163,184,0.35)}
+.dark .forum-sublabel{color:#e2e8f0}
+.dark .forum-error{color:#fca5a5}
+.dark .forum-warning{color:#fcd34d}
+.dark .forum-pill{background:rgba(56,189,248,0.2);color:#bae6fd}
+.dark .forum-media-link{color:#bae6fd}
+.dark .forum-links a{color:#bae6fd}
 .dark .card:hover{
   border-color:rgba(56,189,248,0.5);
   box-shadow:

--- a/forums/index.html
+++ b/forums/index.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Community Forum — Extynct Studios</title>
+  <meta name="description" content="Share your builds, feedback, and fan creations with the Extynct Studios community." />
+  <link rel="icon" type="image/png" href="/assets/images/8.jpg" />
+  <link rel="apple-touch-icon" href="/assets/images/8.jpg" />
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
+  <script src="/assets/forum.js" defer></script>
+</head>
+<body>
+  <div data-include="/partials/header.html"></div>
+
+  <main id="forum-root" class="forum">
+    <section class="page-hero">
+      <div class="container">
+        <h1>Community Forum</h1>
+        <p class="forum-subtitle">Swap tips, showcase progress, and connect with fellow Extynct Studios players. Posts are stored locally so you can prototype ideas without creating an account.</p>
+      </div>
+    </section>
+
+    <section class="container forum-layout">
+      <div class="forum-main">
+        <article class="card forum-form-card">
+          <div class="card-body">
+            <h2 class="forum-form-title">Create a post</h2>
+            <p class="forum-storage-note">Everything you share here is saved in your browser using local storage. Clear your cache to wipe the slate.</p>
+            <form id="forum-form" class="forum-form" novalidate>
+              <div class="forum-field">
+                <label for="forum-author">Display name</label>
+                <input id="forum-author" name="author" type="text" maxlength="40" placeholder="Ex: NovaRacer" autocomplete="nickname" />
+              </div>
+
+              <div class="forum-field">
+                <label for="forum-category">Channel</label>
+                <select id="forum-category" name="category">
+                  <option value="General">General</option>
+                  <option value="Showcase">Showcase</option>
+                  <option value="Feedback">Feedback</option>
+                  <option value="Support">Support</option>
+                  <option value="Off Topic">Off Topic</option>
+                </select>
+              </div>
+
+              <div class="forum-field">
+                <label for="forum-title">Post title <span aria-hidden="true">*</span></label>
+                <input id="forum-title" name="title" type="text" maxlength="120" required placeholder="What's on your mind?" />
+              </div>
+
+              <div class="forum-field">
+                <label for="forum-body">Details <span aria-hidden="true">*</span></label>
+                <textarea id="forum-body" name="body" rows="5" maxlength="2000" required placeholder="Share context, progress, or questions…"></textarea>
+              </div>
+
+              <fieldset class="forum-field">
+                <legend>Media (optional)</legend>
+                <p class="forum-field-help">Attach a file (images up to 5&nbsp;MB, videos up to 20&nbsp;MB) or drop in a direct link. You can showcase screenshots, gifs, or clips.</p>
+                <label class="forum-sublabel" for="forum-media-file">Upload from device</label>
+                <input id="forum-media-file" name="mediaFile" type="file" accept="image/*,video/*" />
+                <label class="forum-sublabel" for="forum-media-link">Or paste a media link</label>
+                <input id="forum-media-link" name="mediaLink" type="url" placeholder="https://example.com/clip.mp4" inputmode="url" />
+              </fieldset>
+
+              <p id="forum-form-error" class="forum-error" role="alert" hidden></p>
+              <p id="forum-storage-warning" class="forum-warning" hidden>Heads up: Your browser blocked local storage, so new posts will only live until you refresh.</p>
+
+              <button type="submit" class="btn btn-primary forum-submit">Share post</button>
+            </form>
+          </div>
+        </article>
+
+        <section class="forum-threads">
+          <header class="forum-threads-header">
+            <h2>Latest activity</h2>
+            <button type="button" class="btn forum-reset" id="forum-reset" aria-describedby="forum-reset-hint">Reset demo posts</button>
+          </header>
+          <p id="forum-reset-hint" class="forum-reset-hint">Use this to restore the starter threads if you cleared them.</p>
+
+          <p id="forum-empty" class="forum-empty" hidden>No posts yet. Be the first to start a conversation!</p>
+          <div id="forum-posts" class="forum-thread-list" aria-live="polite"></div>
+        </section>
+      </div>
+
+      <aside class="forum-sidebar">
+        <article class="card">
+          <div class="card-body">
+            <h2 class="forum-sidebar-title">Posting guidelines</h2>
+            <ul class="forum-guidelines">
+              <li>Keep feedback constructive and actionable.</li>
+              <li>Tag spoilers and major plot beats.</li>
+              <li>Credit artists if you share fan work.</li>
+              <li>Use the Support channel for bug reports or tech issues.</li>
+              <li>Flag anything unsafe via <a href="mailto:hello@extynctstudios.com">hello@extynctstudios.com</a>.</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="card">
+          <div class="card-body">
+            <h2 class="forum-sidebar-title">Quick links</h2>
+            <ul class="forum-links">
+              <li><a href="https://discord.extynctstudios.com/" target="_blank" rel="noopener">Official Discord</a></li>
+              <li><a href="/news/">Latest devlogs</a></li>
+              <li><a href="/games/">Playtest builds</a></li>
+              <li><a href="/privacy-policy.html">Privacy policy</a></li>
+            </ul>
+          </div>
+        </article>
+      </aside>
+    </section>
+  </main>
+
+  <div data-include="/partials/footer.html"></div>
+</body>
+</html>

--- a/forums/index.html
+++ b/forums/index.html
@@ -18,12 +18,55 @@
     <section class="page-hero">
       <div class="container">
         <h1>Community Forum</h1>
-        <p class="forum-subtitle">Swap tips, showcase progress, and connect with fellow Extynct Studios players. Posts are stored locally so you can prototype ideas without creating an account.</p>
+        <p class="forum-subtitle">Swap tips, showcase progress, and connect with fellow Extynct Studios players. Everything is stored locally, and you can add an optional demo account to reuse your display name.</p>
       </div>
     </section>
 
     <section class="container forum-layout">
       <div class="forum-main">
+        <article class="card forum-account-card" aria-labelledby="forum-account-heading">
+          <div class="card-body">
+            <h2 id="forum-account-heading" class="forum-account-title">Create a forum account</h2>
+            <p class="forum-account-intro">Set up a local demo account to autofill your posts. Accounts live only in this browser so you can experiment without sharing personal data.</p>
+
+            <form id="forum-account-form" class="forum-account-form" novalidate>
+              <div class="forum-field">
+                <label for="forum-account-name">Display name <span aria-hidden="true">*</span></label>
+                <input id="forum-account-name" name="displayName" type="text" maxlength="40" autocomplete="nickname" required placeholder="Ex: DriftPilot" />
+              </div>
+
+              <div class="forum-field">
+                <label for="forum-account-email">Email <span aria-hidden="true">*</span></label>
+                <input id="forum-account-email" name="email" type="email" maxlength="120" autocomplete="email" required placeholder="you@example.com" />
+              </div>
+
+              <div class="forum-field">
+                <label for="forum-account-password">Password <span aria-hidden="true">*</span></label>
+                <input id="forum-account-password" name="password" type="password" minlength="8" maxlength="64" autocomplete="new-password" required placeholder="At least 8 characters" />
+              </div>
+
+              <div class="forum-field">
+                <label for="forum-account-confirm">Confirm password <span aria-hidden="true">*</span></label>
+                <input id="forum-account-confirm" name="confirm" type="password" minlength="8" maxlength="64" autocomplete="new-password" required placeholder="Re-enter password" />
+              </div>
+
+              <p id="forum-account-error" class="forum-error" role="alert" hidden></p>
+              <p id="forum-account-success" class="forum-success" role="status" hidden></p>
+
+              <button type="submit" class="btn btn-primary">Save account</button>
+            </form>
+
+            <section class="forum-account-manage" aria-live="polite">
+              <h3 id="forum-account-status" class="forum-account-status">No account selected</h3>
+              <div class="forum-field forum-account-select" hidden>
+                <label for="forum-account-picker">Switch account</label>
+                <select id="forum-account-picker" name="account"></select>
+              </div>
+              <button type="button" id="forum-account-signout" class="btn forum-account-signout" hidden>Sign out</button>
+            </section>
+          </div>
+        </article>
+
         <article class="card forum-form-card">
           <div class="card-body">
             <h2 class="forum-form-title">Create a post</h2>

--- a/forums/index.html
+++ b/forums/index.html
@@ -18,52 +18,21 @@
     <section class="page-hero">
       <div class="container">
         <h1>Community Forum</h1>
-        <p class="forum-subtitle">Swap tips, showcase progress, and connect with fellow Extynct Studios players. Everything is stored locally, and you can add an optional demo account to reuse your display name.</p>
+        <p class="forum-subtitle">Sign in with your Extynct Studios account to join conversations, share feedback, and showcase your creations. Everything remains stored locally in your browser.</p>
+        <a class="btn forum-hero-action" href="/account/">Manage your account</a>
       </div>
     </section>
 
     <section class="container forum-layout">
       <div class="forum-main">
-        <article class="card forum-account-card" aria-labelledby="forum-account-heading">
+        <article class="card forum-session-card" aria-labelledby="forum-session-heading">
           <div class="card-body">
-            <h2 id="forum-account-heading" class="forum-account-title">Create a forum account</h2>
-            <p class="forum-account-intro">Set up a local demo account to autofill your posts. Accounts live only in this browser so you can experiment without sharing personal data.</p>
-
-            <form id="forum-account-form" class="forum-account-form" novalidate>
-              <div class="forum-field">
-                <label for="forum-account-name">Display name <span aria-hidden="true">*</span></label>
-                <input id="forum-account-name" name="displayName" type="text" maxlength="40" autocomplete="nickname" required placeholder="Ex: DriftPilot" />
-              </div>
-
-              <div class="forum-field">
-                <label for="forum-account-email">Email <span aria-hidden="true">*</span></label>
-                <input id="forum-account-email" name="email" type="email" maxlength="120" autocomplete="email" required placeholder="you@example.com" />
-              </div>
-
-              <div class="forum-field">
-                <label for="forum-account-password">Password <span aria-hidden="true">*</span></label>
-                <input id="forum-account-password" name="password" type="password" minlength="8" maxlength="64" autocomplete="new-password" required placeholder="At least 8 characters" />
-              </div>
-
-              <div class="forum-field">
-                <label for="forum-account-confirm">Confirm password <span aria-hidden="true">*</span></label>
-                <input id="forum-account-confirm" name="confirm" type="password" minlength="8" maxlength="64" autocomplete="new-password" required placeholder="Re-enter password" />
-              </div>
-
-              <p id="forum-account-error" class="forum-error" role="alert" hidden></p>
-              <p id="forum-account-success" class="forum-success" role="status" hidden></p>
-
-              <button type="submit" class="btn btn-primary">Save account</button>
-            </form>
-
-            <section class="forum-account-manage" aria-live="polite">
-              <h3 id="forum-account-status" class="forum-account-status">No account selected</h3>
-              <div class="forum-field forum-account-select" hidden>
-                <label for="forum-account-picker">Switch account</label>
-                <select id="forum-account-picker" name="account"></select>
-              </div>
-              <button type="button" id="forum-account-signout" class="btn forum-account-signout" hidden>Sign out</button>
-            </section>
+            <h2 id="forum-session-heading" class="forum-session-title">Forum access</h2>
+            <p id="forum-session-status" class="forum-session-status" aria-live="polite">Checking your sign-in status…</p>
+            <div class="forum-session-actions">
+              <a id="forum-manage-account" class="btn" href="/account/">Account settings</a>
+              <button type="button" id="forum-signout" class="btn" hidden>Sign out</button>
+            </div>
           </div>
         </article>
 
@@ -72,10 +41,7 @@
             <h2 class="forum-form-title">Create a post</h2>
             <p class="forum-storage-note">Everything you share here is saved in your browser using local storage. Clear your cache to wipe the slate.</p>
             <form id="forum-form" class="forum-form" novalidate>
-              <div class="forum-field">
-                <label for="forum-author">Display name</label>
-                <input id="forum-author" name="author" type="text" maxlength="40" placeholder="Ex: NovaRacer" autocomplete="nickname" />
-              </div>
+              <p id="forum-form-locked" class="forum-locked" hidden>You need to sign in before posting. <a href="/account/">Create or sign in to an account</a> and then return to the forum.</p>
 
               <div class="forum-field">
                 <label for="forum-category">Channel</label>
@@ -118,10 +84,7 @@
         <section class="forum-threads">
           <header class="forum-threads-header">
             <h2>Latest activity</h2>
-            <button type="button" class="btn forum-reset" id="forum-reset" aria-describedby="forum-reset-hint">Reset demo posts</button>
           </header>
-          <p id="forum-reset-hint" class="forum-reset-hint">Use this to restore the starter threads if you cleared them.</p>
-
           <p id="forum-empty" class="forum-empty" hidden>No posts yet. Be the first to start a conversation!</p>
           <div id="forum-posts" class="forum-thread-list" aria-live="polite"></div>
         </section>

--- a/partials/header.html
+++ b/partials/header.html
@@ -8,6 +8,7 @@
       <a class="nav-btn" href="/games/">Games</a>
       <a class="nav-btn" href="/news/">News</a>
       <a class="nav-btn" href="/team/">Team & Thanks</a>
+      <a class="nav-btn" href="/account/">Account</a>
       <a class="nav-btn" href="/forums/">Community Forum</a>
       <button class="nav-btn" type="button" onclick="toggleTheme()">Toggle Theme</button>
     </nav>

--- a/partials/header.html
+++ b/partials/header.html
@@ -8,6 +8,7 @@
       <a class="nav-btn" href="/games/">Games</a>
       <a class="nav-btn" href="/news/">News</a>
       <a class="nav-btn" href="/team/">Team & Thanks</a>
+      <a class="nav-btn" href="/forums/">Community Forum</a>
       <button class="nav-btn" type="button" onclick="toggleTheme()">Toggle Theme</button>
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- add a Community Forum navigation entry and standalone page
- implement a local-storage powered demo forum with media attachments
- style the forum experience with responsive layout and dark mode adjustments

## Testing
- manual: `python -m http.server 8000` and navigate to /forums/

------
https://chatgpt.com/codex/tasks/task_e_68edda5297948332a26c9759c48ba134