### PR TITLE
Store forum data locally in the browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -37,8 +37,21 @@ If you are interested in collaboration or licensing, please contact us directly.
 ## 🛠️ Tech Stack
 
 - **HTML5, CSS3, JavaScript**  
-- **TailwindCSS** for styling  
-- **Static Hosting** (GitHub Pages / external server)  
+- **TailwindCSS** inspired utility styles
+- **Static Hosting** (GitHub Pages / external server)
+- **Client-side local storage** for forum persistence
+
+---
+
+## 🧪 Local development & storage
+
+The site runs entirely on static hosting. Forum accounts and posts are saved with the visitor's browser storage, so nothing is synced or committed back to the repository.
+
+1. Open `/account/` to create a username, email, and password. Passwords are hashed before they are stored locally.
+2. Sign in on the same page—once signed in, your status is remembered in this browser so you can post on `/forums/`.
+3. Share text, images (up to 2&nbsp;MB), short video clips (up to 6&nbsp;MB), or links on the forum. Attachments are stored as data URLs inside the same local storage bucket.
+
+If the browser blocks local storage (e.g., strict privacy or incognito modes), accounts and posts will only last for the current session.
 
 ---
 

--- a/account/index.html
+++ b/account/index.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Account Manager — Extynct Studios</title>
+  <meta name="description" content="Create an Extynct Studios forum account and manage your sign-in directly from this site." />
+  <link rel="icon" type="image/png" href="/assets/images/8.jpg" />
+  <link rel="apple-touch-icon" href="/assets/images/8.jpg" />
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
+  <script src="/assets/community-storage.js" defer></script>
+  <script src="/assets/account.js" defer></script>
+</head>
+<body>
+  <div data-include="/partials/header.html"></div>
+
+  <main id="account-root" class="account">
+    <section class="page-hero">
+      <div class="container">
+        <h1>Manage your account</h1>
+        <p class="account-subtitle">Create a sign-in you can use for the community forum. Everything is stored right in this browser, so your details stay on this device.</p>
+      </div>
+    </section>
+
+    <section class="container account-layout">
+      <article class="card account-card" aria-labelledby="account-create-heading">
+        <div class="card-body">
+          <h2 id="account-create-heading" class="account-card-title">Create a new account</h2>
+          <p class="account-card-intro">Use a unique username and a password with at least eight characters. Your email helps identify the account if you ever need to reset it.</p>
+
+          <form id="account-create-form" class="account-form" novalidate>
+            <div class="account-field">
+              <label for="account-create-username">Username <span aria-hidden="true">*</span></label>
+              <input id="account-create-username" name="username" type="text" maxlength="32" autocomplete="username" required placeholder="Ex: DriftPilot" />
+            </div>
+
+            <div class="account-field">
+              <label for="account-create-email">Email <span aria-hidden="true">*</span></label>
+              <input id="account-create-email" name="email" type="email" maxlength="120" autocomplete="email" required placeholder="you@example.com" />
+            </div>
+
+            <div class="account-field">
+              <label for="account-create-password">Password <span aria-hidden="true">*</span></label>
+              <input id="account-create-password" name="password" type="password" minlength="8" maxlength="64" autocomplete="new-password" required placeholder="At least 8 characters" />
+            </div>
+
+            <div class="account-field">
+              <label for="account-create-confirm">Confirm password <span aria-hidden="true">*</span></label>
+              <input id="account-create-confirm" name="confirm" type="password" minlength="8" maxlength="64" autocomplete="new-password" required placeholder="Re-enter password" />
+            </div>
+
+            <p id="account-create-error" class="account-error" role="alert" hidden></p>
+            <p id="account-create-success" class="account-success" role="status" hidden></p>
+
+            <button type="submit" class="btn btn-primary">Create account</button>
+          </form>
+        </div>
+      </article>
+
+      <article class="card account-card" aria-labelledby="account-signin-heading">
+        <div class="card-body">
+          <h2 id="account-signin-heading" class="account-card-title">Sign in</h2>
+          <p class="account-card-intro">Already created an account? Sign in with your email or username and password. Once signed in you can post on the community forum.</p>
+
+          <form id="account-signin-form" class="account-form" novalidate>
+            <div class="account-field">
+              <label for="account-signin-identifier">Email or username <span aria-hidden="true">*</span></label>
+              <input id="account-signin-identifier" name="identifier" type="text" autocomplete="username" required placeholder="yourname or you@example.com" />
+            </div>
+
+            <div class="account-field">
+              <label for="account-signin-password">Password <span aria-hidden="true">*</span></label>
+              <input id="account-signin-password" name="password" type="password" minlength="8" maxlength="64" autocomplete="current-password" required placeholder="Your password" />
+            </div>
+
+            <p id="account-signin-error" class="account-error" role="alert" hidden></p>
+            <p id="account-signin-success" class="account-success" role="status" hidden></p>
+            <button type="submit" class="btn btn-primary">Sign in</button>
+          </form>
+
+          <p id="account-active-status" class="account-active-status" aria-live="polite">Not signed in.</p>
+          <button type="button" id="account-signout" class="btn" hidden>Sign out</button>
+          <p id="account-storage-warning" class="account-warning" hidden>Heads up: your browser blocked local storage, so your sign-in will reset after you close this tab.</p>
+
+          <p class="account-hint">Need to start posting? Head back to the <a href="/forums/">community forum</a>.</p>
+        </div>
+      </article>
+
+      <article class="card account-card" aria-labelledby="account-info-heading">
+        <div class="card-body">
+          <h2 id="account-info-heading" class="account-card-title">How storage works</h2>
+          <p class="account-card-intro">Accounts live entirely in your browser using local storage. That keeps everything on this device—no servers or uploads required.</p>
+          <p class="account-card-intro">If your browser clears site data or blocks storage, your saved accounts will disappear and you’ll need to recreate them.</p>
+          <p class="account-hint">To post on the forum, create an account here, sign in, and then visit the <a href="/forums/">Community Forum</a> page.</p>
+        </div>
+      </article>
+    </section>
+  </main>
+
+  <div data-include="/partials/footer.html"></div>
+</body>
+</html>

--- a/assets/account.js
+++ b/assets/account.js
@@ -1,0 +1,239 @@
+(function(){
+  const ROOT = document.getElementById('account-root');
+  if(!ROOT || !window.communityStorage){
+    return;
+  }
+
+  const storage = window.communityStorage;
+
+  const createForm = document.getElementById('account-create-form');
+  const createErrorEl = document.getElementById('account-create-error');
+  const createSuccessEl = document.getElementById('account-create-success');
+
+  const signInForm = document.getElementById('account-signin-form');
+  const signInErrorEl = document.getElementById('account-signin-error');
+  const signInSuccessEl = document.getElementById('account-signin-success');
+
+  const activeStatusEl = document.getElementById('account-active-status');
+  const signOutButton = document.getElementById('account-signout');
+  const storageWarningEl = document.getElementById('account-storage-warning');
+
+  let activeAccount = storage.getActiveAccount();
+
+  function showMessage(element, message){
+    if(!element){
+      return;
+    }
+    element.hidden = false;
+    element.textContent = message;
+  }
+
+  function hideMessage(element){
+    if(!element){
+      return;
+    }
+    element.hidden = true;
+    element.textContent = '';
+  }
+
+  function clearFormMessages(){
+    [createErrorEl, createSuccessEl, signInErrorEl, signInSuccessEl].forEach(hideMessage);
+  }
+
+  function normalize(value){
+    return String(value || '').trim();
+  }
+
+  function normalizeIdentifier(value){
+    return String(value || '').trim();
+  }
+
+  function normalizeEmail(value){
+    return String(value || '').trim().toLowerCase();
+  }
+
+  function updateActiveStatus(customMessage){
+    if(activeStatusEl){
+      if(customMessage){
+        activeStatusEl.textContent = customMessage;
+      }else if(activeAccount){
+        activeStatusEl.textContent = `Signed in as @${activeAccount.username}.`;
+      }else{
+        activeStatusEl.textContent = 'Not signed in.';
+      }
+    }
+    if(signOutButton){
+      signOutButton.hidden = !activeAccount;
+    }
+  }
+
+  function updateStorageWarning(forceShow){
+    if(!storageWarningEl){
+      return;
+    }
+    const shouldShow = Boolean(forceShow) || !storage.hasStorage();
+    storageWarningEl.hidden = !shouldShow;
+  }
+
+  function resetForms(){
+    if(createForm){
+      createForm.reset();
+    }
+    if(signInForm){
+      signInForm.reset();
+    }
+  }
+
+  async function handleCreate(event){
+    event.preventDefault();
+    clearFormMessages();
+
+    if(!createForm){
+      return;
+    }
+
+    const formData = new FormData(createForm);
+    const username = normalize(formData.get('username'));
+    const emailRaw = String(formData.get('email') || '').trim();
+    const email = normalizeEmail(emailRaw);
+    const password = String(formData.get('password') || '');
+    const confirm = String(formData.get('confirm') || '');
+
+    if(!username || !emailRaw){
+      showMessage(createErrorEl, 'Username and email are required.');
+      return;
+    }
+
+    if(password.length < 8){
+      showMessage(createErrorEl, 'Use a password with at least eight characters.');
+      return;
+    }
+
+    if(password !== confirm){
+      showMessage(createErrorEl, 'Passwords do not match.');
+      return;
+    }
+
+    let accounts = storage.getAccounts();
+    const usernameLower = username.toLowerCase();
+    const emailLower = email;
+
+    if(accounts.some((account) => String(account.username || '').toLowerCase() === usernameLower)){
+      showMessage(createErrorEl, 'That username is already taken.');
+      return;
+    }
+
+    if(accounts.some((account) => String(account.email || '').toLowerCase() === emailLower)){
+      showMessage(createErrorEl, 'That email already has an account.');
+      return;
+    }
+
+    let passwordHash;
+    try{
+      passwordHash = await storage.hashPassword(password);
+    }catch(err){
+      showMessage(createErrorEl, 'Unable to process the password in this browser.');
+      return;
+    }
+
+    const newAccount = {
+      id: storage.createUid('acct'),
+      username,
+      email,
+      passwordHash,
+      createdAt: new Date().toISOString()
+    };
+
+    accounts.push(newAccount);
+    const accountsStored = storage.saveAccounts(accounts);
+
+    activeAccount = { username, email: emailRaw };
+    const sessionStored = storage.setActiveAccount(activeAccount);
+
+    const persistent = accountsStored && sessionStored && storage.hasStorage();
+
+    showMessage(createSuccessEl, persistent ? 'Account created and saved to this browser.' : 'Account created for this session. Enable local storage to keep it after you close the tab.');
+
+    resetForms();
+    updateActiveStatus();
+    updateStorageWarning(!(accountsStored && sessionStored));
+  }
+
+  async function handleSignIn(event){
+    event.preventDefault();
+    clearFormMessages();
+
+    if(!signInForm){
+      return;
+    }
+
+    const formData = new FormData(signInForm);
+    const identifierRaw = normalizeIdentifier(formData.get('identifier'));
+    const password = String(formData.get('password') || '');
+
+    if(!identifierRaw || !password){
+      showMessage(signInErrorEl, 'Enter your email or username and password.');
+      return;
+    }
+
+    const accounts = storage.getAccounts();
+    if(!Array.isArray(accounts) || accounts.length === 0){
+      showMessage(signInErrorEl, 'No accounts exist yet. Create one first.');
+      return;
+    }
+
+    const identifierLower = identifierRaw.toLowerCase();
+    const match = accounts.find((account) => {
+      const usernameMatch = String(account.username || '').toLowerCase() === identifierLower;
+      const emailMatch = String(account.email || '').toLowerCase() === identifierLower;
+      return usernameMatch || emailMatch;
+    });
+
+    if(!match){
+      showMessage(signInErrorEl, 'No account found for that email or username.');
+      return;
+    }
+
+    let hashedInput;
+    try{
+      hashedInput = await storage.hashPassword(password);
+    }catch(err){
+      showMessage(signInErrorEl, 'Unable to process the password in this browser.');
+      return;
+    }
+
+    if(hashedInput !== match.passwordHash){
+      showMessage(signInErrorEl, 'Incorrect password.');
+      return;
+    }
+
+    activeAccount = { username: match.username, email: match.email || '' };
+    const sessionStored = storage.setActiveAccount(activeAccount);
+    showMessage(signInSuccessEl, sessionStored && storage.hasStorage() ? 'Signed in successfully.' : 'Signed in for this session. Enable local storage to stay signed in.');
+
+    signInForm.reset();
+    updateActiveStatus();
+    updateStorageWarning(!sessionStored);
+  }
+
+  function handleSignOut(){
+    clearFormMessages();
+    storage.clearActiveAccount();
+    activeAccount = null;
+    updateActiveStatus('Signed out.');
+    updateStorageWarning(!storage.hasStorage());
+  }
+
+  if(createForm){
+    createForm.addEventListener('submit', handleCreate);
+  }
+  if(signInForm){
+    signInForm.addEventListener('submit', handleSignIn);
+  }
+  if(signOutButton){
+    signOutButton.addEventListener('click', handleSignOut);
+  }
+
+  updateActiveStatus();
+  updateStorageWarning(!storage.hasStorage() && !activeAccount);
+})();

--- a/assets/community-storage.js
+++ b/assets/community-storage.js
@@ -1,0 +1,168 @@
+(function(){
+  const KEYS = {
+    accounts: 'extynct.accounts',
+    activeAccount: 'extynct.activeAccount',
+    posts: 'extynct.posts'
+  };
+
+  const memory = {};
+
+  function hasNativeStorage(){
+    try{
+      const testKey = '__extynct_test__';
+      localStorage.setItem(testKey, '1');
+      localStorage.removeItem(testKey);
+      return true;
+    }catch(err){
+      return false;
+    }
+  }
+
+  const storageSupported = hasNativeStorage();
+
+  function cloneValue(value){
+    if(typeof structuredClone === 'function'){
+      try{
+        return structuredClone(value);
+      }catch(err){
+        // fall through to manual clone
+      }
+    }
+
+    if(Array.isArray(value)){
+      return value.map((item) => cloneValue(item));
+    }
+    if(value && typeof value === 'object'){
+      const cloned = {};
+      for(const key in value){
+        if(Object.prototype.hasOwnProperty.call(value, key)){
+          cloned[key] = cloneValue(value[key]);
+        }
+      }
+      return cloned;
+    }
+    return value;
+  }
+
+  function read(key, fallback){
+    if(Object.prototype.hasOwnProperty.call(memory, key)){
+      return cloneValue(memory[key]);
+    }
+
+    let value = fallback;
+    if(storageSupported){
+      try{
+        const raw = localStorage.getItem(key);
+        if(raw !== null){
+          value = JSON.parse(raw);
+        }
+      }catch(err){
+        value = fallback;
+      }
+    }
+
+    memory[key] = value;
+    return cloneValue(value);
+  }
+
+  function write(key, value){
+    memory[key] = cloneValue(value);
+
+    if(!storageSupported){
+      return false;
+    }
+
+    try{
+      if(value === undefined || value === null){
+        localStorage.removeItem(key);
+      }else{
+        localStorage.setItem(key, JSON.stringify(value));
+      }
+      return true;
+    }catch(err){
+      return false;
+    }
+  }
+
+  async function hashPassword(password){
+    const text = String(password || '');
+    if(window.crypto && window.crypto.subtle && window.TextEncoder){
+      const encoded = new TextEncoder().encode(text);
+      const hashBuffer = await window.crypto.subtle.digest('SHA-256', encoded);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+    }
+
+    let hash = 0;
+    for(let i = 0; i < text.length; i += 1){
+      hash = (hash << 5) - hash + text.charCodeAt(i);
+      hash |= 0;
+    }
+    return `fallback-${Math.abs(hash)}`;
+  }
+
+  function createUid(prefix){
+    const random = Math.random().toString(36).slice(2, 10);
+    const time = Date.now().toString(36);
+    return `${prefix || 'id'}_${random}${time}`;
+  }
+
+  function getAccounts(){
+    const accounts = read(KEYS.accounts, []);
+    return Array.isArray(accounts) ? accounts : [];
+  }
+
+  function saveAccounts(accounts){
+    const safe = Array.isArray(accounts) ? accounts : [];
+    return write(KEYS.accounts, safe);
+  }
+
+  function getActiveAccount(){
+    const account = read(KEYS.activeAccount, null);
+    if(account && typeof account === 'object'){
+      return {
+        username: String(account.username || ''),
+        email: String(account.email || '')
+      };
+    }
+    return null;
+  }
+
+  function setActiveAccount(account){
+    if(!account){
+      return write(KEYS.activeAccount, null);
+    }
+    const payload = {
+      username: String(account.username || ''),
+      email: String(account.email || '')
+    };
+    return write(KEYS.activeAccount, payload);
+  }
+
+  function clearActiveAccount(){
+    return write(KEYS.activeAccount, null);
+  }
+
+  function getPosts(){
+    const posts = read(KEYS.posts, []);
+    return Array.isArray(posts) ? posts : [];
+  }
+
+  function savePosts(posts){
+    const safe = Array.isArray(posts) ? posts : [];
+    return write(KEYS.posts, safe);
+  }
+
+  window.communityStorage = {
+    hasStorage: () => storageSupported,
+    getAccounts,
+    saveAccounts,
+    getActiveAccount,
+    setActiveAccount,
+    clearActiveAccount,
+    getPosts,
+    savePosts,
+    createUid,
+    hashPassword
+  };
+})();

--- a/assets/forum.js
+++ b/assets/forum.js
@@ -1,0 +1,387 @@
+(function(){
+  const ROOT = document.getElementById('forum-root');
+  if(!ROOT || !window.communityStorage){
+    return;
+  }
+
+  const storage = window.communityStorage;
+
+  const form = document.getElementById('forum-form');
+  const postsContainer = document.getElementById('forum-posts');
+  const emptyState = document.getElementById('forum-empty');
+  const lockedMessage = document.getElementById('forum-form-locked');
+  const errorEl = document.getElementById('forum-form-error');
+  const successEl = document.getElementById('forum-form-success');
+  const storageWarning = document.getElementById('forum-storage-warning');
+  const sessionStatusEl = document.getElementById('forum-session-status');
+  const signOutButton = document.getElementById('forum-signout');
+
+  const mediaFileInput = document.getElementById('forum-media-file');
+  const mediaLinkInput = document.getElementById('forum-media-link');
+
+  const defaultEmptyMessage = emptyState ? emptyState.textContent : '';
+
+  const IMAGE_LIMIT = 2 * 1024 * 1024; // 2 MB
+  const VIDEO_LIMIT = 6 * 1024 * 1024; // 6 MB
+
+  let posts = storage.getPosts();
+  let activeAccount = storage.getActiveAccount();
+  let isSubmitting = false;
+
+  function escapeHtml(value){
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function clearMessages(){
+    if(errorEl){
+      errorEl.hidden = true;
+      errorEl.textContent = '';
+    }
+    if(successEl){
+      successEl.hidden = true;
+      successEl.textContent = '';
+    }
+  }
+
+  function showError(message){
+    if(!errorEl){
+      return;
+    }
+    errorEl.textContent = message;
+    errorEl.hidden = false;
+    if(successEl){
+      successEl.hidden = true;
+      successEl.textContent = '';
+    }
+  }
+
+  function showSuccess(message){
+    if(!successEl){
+      return;
+    }
+    successEl.textContent = message;
+    successEl.hidden = false;
+    if(errorEl){
+      errorEl.hidden = true;
+      errorEl.textContent = '';
+    }
+  }
+
+  function setFormEnabled(enabled){
+    if(!form){
+      return;
+    }
+    form.classList.toggle('forum-form-disabled', !enabled);
+    const fields = form.querySelectorAll('input, textarea, select, button');
+    fields.forEach((field) => {
+      if(field.type === 'button'){
+        return;
+      }
+      field.disabled = !enabled;
+    });
+    if(lockedMessage){
+      lockedMessage.hidden = enabled;
+    }
+  }
+
+  function setSubmitting(state){
+    isSubmitting = state;
+    if(!form){
+      return;
+    }
+    const submitButton = form.querySelector('button[type="submit"]');
+    if(submitButton){
+      submitButton.disabled = state || !activeAccount;
+      submitButton.textContent = state ? 'Sharing…' : 'Share post';
+    }
+  }
+
+  function updateStorageWarning(forceShow){
+    if(!storageWarning){
+      return;
+    }
+    const shouldShow = Boolean(forceShow) || !storage.hasStorage();
+    storageWarning.hidden = !shouldShow;
+  }
+
+  function updateSessionStatus(customMessage){
+    activeAccount = storage.getActiveAccount();
+    if(sessionStatusEl){
+      if(customMessage){
+        sessionStatusEl.textContent = customMessage;
+      }else if(activeAccount){
+        sessionStatusEl.textContent = 'Signed in as @' + activeAccount.username + '. Posts stay on this device.';
+      }else{
+        sessionStatusEl.textContent = 'Not signed in. Visit the account page to create or sign in.';
+      }
+    }
+    if(signOutButton){
+      signOutButton.hidden = !activeAccount;
+    }
+    setFormEnabled(Boolean(activeAccount));
+  }
+
+  function validateLink(url){
+    if(!url){
+      return false;
+    }
+    try{
+      const parsed = new URL(url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    }catch(err){
+      return false;
+    }
+  }
+
+  function readFileAsDataUrl(file){
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result || ''));
+      reader.onerror = () => reject(new Error('Unable to read the selected file.'));
+      reader.readAsDataURL(file);
+    });
+  }
+
+  function renderMedia(media){
+    if(!media){
+      return '';
+    }
+
+    if(media.type === 'file'){
+      const dataUrl = media.dataUrl || '';
+      if(!dataUrl){
+        return '';
+      }
+      const isVideo = /^video\//i.test(media.mimeType || '');
+      if(isVideo){
+        return `
+          <div class="forum-media-group">
+            <div class="forum-media">
+              <video controls preload="metadata">
+                <source src="${escapeHtml(dataUrl)}" type="${escapeHtml(media.mimeType || 'video/mp4')}" />
+                Your browser does not support the video tag.
+              </video>
+            </div>
+          </div>`;
+      }
+      return `
+        <div class="forum-media-group">
+          <div class="forum-media">
+            <img src="${escapeHtml(dataUrl)}" alt="Attachment from ${escapeHtml(media.originalName || 'post')}" loading="lazy" />
+          </div>
+        </div>`;
+    }
+
+    if(media.type === 'link'){
+      const safeUrl = escapeHtml(media.url || '');
+      if(!safeUrl){
+        return '';
+      }
+      return `
+        <div class="forum-media-group">
+          <div class="forum-media">
+            <a class="forum-media-link" href="${safeUrl}" target="_blank" rel="noopener">View attached media</a>
+          </div>
+        </div>`;
+    }
+
+    return '';
+  }
+
+  function renderPosts(){
+    if(!postsContainer){
+      return;
+    }
+
+    const list = Array.isArray(posts) ? posts.slice() : [];
+    if(list.length === 0){
+      if(emptyState){
+        emptyState.textContent = defaultEmptyMessage;
+        emptyState.hidden = false;
+      }
+      postsContainer.innerHTML = '';
+      return;
+    }
+
+    list.sort((a, b) => {
+      const aTime = new Date(a && a.createdAt ? a.createdAt : 0).getTime();
+      const bTime = new Date(b && b.createdAt ? b.createdAt : 0).getTime();
+      return bTime - aTime;
+    });
+
+    if(emptyState){
+      emptyState.hidden = true;
+    }
+
+    const markup = list.map((post) => {
+      const created = new Date(post.createdAt || Date.now());
+      const formattedDate = created.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+      const paragraphs = String(post.body || '')
+        .split(/\n+/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => `<p>${escapeHtml(line)}</p>`)
+        .join('');
+
+      const authorName = post.author && post.author.username ? post.author.username : post.authorName || 'unknown';
+
+      return `
+        <article class="card forum-thread" data-post-id="${escapeHtml(post.id || '')}">
+          <div class="card-body forum-thread-body">
+            <header class="forum-thread-header">
+              <h3 class="forum-thread-title">${escapeHtml(post.title || 'Untitled post')}</h3>
+              <div class="forum-thread-meta">
+                <span class="forum-pill">${escapeHtml(post.category || 'General')}</span>
+                <span class="forum-thread-author">@${escapeHtml(authorName || 'unknown')}</span>
+                <time datetime="${escapeHtml(post.createdAt || '')}">${escapeHtml(formattedDate)}</time>
+              </div>
+            </header>
+            ${paragraphs || '<p>No content provided.</p>'}
+            ${renderMedia(post.media)}
+          </div>
+        </article>`;
+    }).join('\n');
+
+    postsContainer.innerHTML = markup;
+  }
+
+  function refreshPosts(){
+    posts = storage.getPosts();
+    renderPosts();
+  }
+
+  async function handleSubmit(event){
+    event.preventDefault();
+    if(isSubmitting){
+      return;
+    }
+
+    clearMessages();
+
+    activeAccount = storage.getActiveAccount();
+    if(!activeAccount){
+      showError('Sign in before posting.');
+      return;
+    }
+
+    if(!form){
+      return;
+    }
+
+    const formData = new FormData(form);
+    const category = String(formData.get('category') || 'General');
+    const title = String(formData.get('title') || '').trim();
+    const body = String(formData.get('body') || '').trim();
+    const file = mediaFileInput && mediaFileInput.files ? mediaFileInput.files[0] : null;
+    const linkValue = mediaLinkInput ? String(mediaLinkInput.value || '').trim() : '';
+
+    if(!title){
+      showError('Give your post a title.');
+      return;
+    }
+    if(!body){
+      showError('Share some details in the body field.');
+      return;
+    }
+    if(file && linkValue){
+      showError('Please choose either an upload or a link, not both.');
+      return;
+    }
+    if(linkValue && !validateLink(linkValue)){
+      showError('Enter a valid media link that starts with http:// or https://.');
+      return;
+    }
+
+    let media = null;
+    if(file){
+      const isVideo = /^video\//i.test(file.type || '');
+      const sizeLimit = isVideo ? VIDEO_LIMIT : IMAGE_LIMIT;
+      if(file.size > sizeLimit){
+        showError(isVideo ? 'Video uploads must be 6 MB or smaller.' : 'Image uploads must be 2 MB or smaller.');
+        return;
+      }
+    }
+
+    setSubmitting(true);
+
+    try{
+      if(file){
+        const dataUrl = await readFileAsDataUrl(file);
+        media = {
+          type: 'file',
+          dataUrl,
+          mimeType: file.type,
+          originalName: file.name
+        };
+      }else if(linkValue){
+        media = {
+          type: 'link',
+          url: linkValue
+        };
+      }
+
+      const newPost = {
+        id: storage.createUid('post'),
+        title,
+        body,
+        category,
+        author: {
+          username: activeAccount.username,
+          email: activeAccount.email || ''
+        },
+        createdAt: new Date().toISOString(),
+        media
+      };
+
+      const updatedPosts = storage.getPosts();
+      updatedPosts.push(newPost);
+      const stored = storage.savePosts(updatedPosts);
+
+      refreshPosts();
+
+      if(form){
+        form.reset();
+      }
+      if(mediaFileInput){
+        mediaFileInput.value = '';
+      }
+
+      if(stored && storage.hasStorage()){
+        showSuccess('Post shared! It will stick around on this device.');
+      }else{
+        showSuccess('Post shared for this session. Enable local storage to keep it after closing the tab.');
+        updateStorageWarning(true);
+      }
+    }catch(err){
+      console.error('Failed to submit forum post.', err);
+      showError(err.message || 'Unable to save the post.');
+    }finally{
+      setSubmitting(false);
+    }
+  }
+
+  function handleSignOut(){
+    storage.clearActiveAccount();
+    activeAccount = null;
+    clearMessages();
+    updateSessionStatus('Signed out.');
+    updateStorageWarning(!storage.hasStorage());
+  }
+
+  if(form){
+    form.addEventListener('submit', handleSubmit);
+  }
+  if(signOutButton){
+    signOutButton.addEventListener('click', handleSignOut);
+  }
+
+  updateStorageWarning(!storage.hasStorage() && !activeAccount);
+  updateSessionStatus();
+  setFormEnabled(Boolean(activeAccount));
+  renderPosts();
+})();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -144,6 +144,87 @@ body{
 .mb-2{margin-bottom:.5rem}.mb-3{margin-bottom:.75rem}.mb-4{margin-bottom:1rem}.mb-6{margin-bottom:1.5rem}.mb-8{margin-bottom:2rem}
 .flex{display:flex}.items-center{align-items:center}.justify-between{justify-content:space-between}.gap-2{gap:.5rem}.gap-3{gap:.75rem}.gap-4{gap:1rem}
 
+/* FORUM */
+.forum-subtitle{color:#475569;margin:1rem 0 0;max-width:60ch}
+.forum-hero-action{margin-top:1.5rem}
+.forum-layout{display:grid;gap:2rem;align-items:flex-start;margin-bottom:3rem;grid-template-columns:minmax(0,1.65fr)minmax(0,.95fr)}
+.forum-main{display:flex;flex-direction:column;gap:1.75rem}
+.forum-form-title{margin:0;font:700 1.2rem/1.25 system-ui}
+.forum-storage-note{color:#475569;margin:.5rem 0 1.25rem;font-size:.95rem}
+.forum-session-card .card-body{display:grid;gap:1rem}
+.forum-session-title{margin:0;font:700 1.1rem/1.25 system-ui}
+.forum-session-status{margin:0;color:#1e293b;font-weight:600}
+.forum-session-actions{display:flex;flex-wrap:wrap;gap:.75rem}
+.forum-session-actions .btn{flex:0 0 auto}
+.forum-success{margin:0;color:#047857;font-weight:600}
+.forum-form{display:grid;gap:1.25rem}
+.forum-field{display:flex;flex-direction:column;gap:.5rem}
+.forum-form label,.forum-form legend,.account-form label{font:600 .95rem/1.2 system-ui;color:#0f172a}
+.forum-form input,.forum-form textarea,.forum-form select,.account-form input{width:100%;padding:.65rem .85rem;border:2px solid rgba(15,23,42,.15);border-radius:.85rem;background:#fff;font:500 .95rem/1.4 system-ui;color:#0f172a;transition:border-color .2s,box-shadow .2s,background .2s}
+.forum-form input:focus,.forum-form textarea:focus,.forum-form select:focus,.account-form input:focus{outline:none;border-color:#0284c7;box-shadow:0 0 0 3px rgba(56,189,248,0.25);background:#f8fafc}
+.forum-form textarea{min-height:8rem;resize:vertical}
+.forum-form fieldset{border:2px dashed rgba(15,23,42,.2);padding:1rem 1.25rem;border-radius:1rem}
+.forum-field-help{margin:-.25rem 0 .5rem;color:#475569;font-size:.9rem}
+.forum-sublabel{font:600 .85rem/1.2 system-ui;color:#1e293b}
+.forum-error{margin:0;color:#dc2626;font-weight:600}
+.forum-warning{margin:0;color:#b45309;font-weight:600}
+.forum-locked{margin:0;color:#b45309;font-weight:600}
+.forum-submit{align-self:flex-start}
+.forum-form-disabled{opacity:.6}
+.forum-threads{display:flex;flex-direction:column;gap:1.5rem}
+.forum-threads-header{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.75rem}
+.forum-empty{margin:0;padding:2.5rem 0;text-align:center;color:#64748b;font-style:italic}
+.forum-thread-list{display:grid;gap:1.5rem}
+.forum-thread-title{margin:0;font:700 1.15rem/1.25 system-ui}
+.forum-thread-meta{display:flex;flex-wrap:wrap;align-items:center;gap:.75rem;margin-top:.5rem;color:#475569;font:500 .85rem/1.2 system-ui}
+.forum-thread-author::before{content:'•';margin:0 .4rem}
+.forum-thread-body p{margin:.85rem 0 0;color:#1f2937}
+.forum-thread-body p:first-of-type{margin-top:.75rem}
+.forum-pill{display:inline-flex;align-items:center;padding:.25rem .65rem;border-radius:999px;background:#e0f2fe;color:#0369a1;font:700 .75rem/1 system-ui;text-transform:uppercase;letter-spacing:.02em}
+.forum-media-group{display:grid;gap:1rem;margin-top:1rem}
+.forum-media{border-radius:1rem;overflow:hidden;box-shadow:0 3px 12px rgba(15,23,42,0.15)}
+.forum-media img,.forum-media video,.forum-media iframe{width:100%;display:block;background:#000}
+.forum-media video,.forum-media iframe{aspect-ratio:16/9}
+.forum-media iframe{border:0}
+.forum-media-link{display:inline-block;padding:1rem;text-decoration:none;color:#0f172a;font-weight:600}
+.forum-media-link:hover{text-decoration:underline}
+.forum-sidebar{display:flex;flex-direction:column;gap:1.5rem}
+.forum-sidebar-title{margin:0;font:700 1.05rem/1.2 system-ui}
+.forum-guidelines,.forum-links{margin:1rem 0 0;padding-left:1.1rem;color:#475569;display:grid;gap:.5rem;font-size:.95rem}
+.forum-links{list-style:none;padding-left:0}
+.forum-links a{text-decoration:none;color:#0f172a;font-weight:600}
+.forum-links a:hover{text-decoration:underline}
+
+/* ACCOUNT */
+.account-subtitle{color:#475569;margin:1rem 0 0;max-width:60ch}
+.account-layout{display:grid;gap:2rem;align-items:flex-start;margin-bottom:3rem;grid-template-columns:repeat(2,minmax(0,1fr))}
+.account-card .card-body{display:grid;gap:1.25rem}
+.account-card-title{margin:0;font:700 1.1rem/1.25 system-ui}
+.account-card-intro{margin:0;color:#475569;font-size:.95rem}
+.account-form{display:grid;gap:1rem}
+.account-field{display:flex;flex-direction:column;gap:.5rem}
+.account-error{margin:0;color:#dc2626;font-weight:600}
+.account-success{margin:0;color:#047857;font-weight:600}
+.account-active-status{margin:1rem 0 0;font:600 1rem/1.3 system-ui;color:#0f172a}
+.account-warning{margin:1rem 0 0;color:#b45309;font-weight:600}
+.account-hint{margin:1rem 0 0;color:#475569;font-size:.95rem}
+.account-hint a{font-weight:600;color:#0f172a;text-decoration:none}
+.account-hint a:hover{text-decoration:underline}
+
+@media (max-width:1024px){
+  .forum-layout{grid-template-columns:1fr}
+  .forum-sidebar{order:-1}
+}
+
+@media (max-width:900px){
+  .account-layout{grid-template-columns:1fr}
+}
+
+@media (max-width:640px){
+  .forum-form fieldset{padding:1rem}
+  .forum-media video,.forum-media iframe{aspect-ratio:4/3}
+}
+
 /* DARK MODE */
 .dark body{background:#0b1220;color:#e5e7eb}
 .dark .navbar{
@@ -158,6 +239,20 @@ body{
     0 4px 8px rgba(0,0,0,0.6),
     0 0 0 3px rgba(56,189,248,0.2);
 }
+.dark .forum-subtitle,.dark .forum-session-status,.dark .forum-storage-note,.dark .forum-thread-meta,.dark .forum-guidelines,.dark .forum-links,.dark .account-subtitle,.dark .account-hint{color:#cbd5f5}
+.dark .forum-form label,.dark .forum-form legend{color:#e2e8f0}
+.dark .forum-form input,.dark .forum-form textarea,.dark .forum-form select,.dark .account-form input{background:#0f172a;color:#e2e8f0;border-color:rgba(148,163,184,0.4)}
+.dark .forum-form input:focus,.dark .forum-form textarea:focus,.dark .forum-form select:focus,.dark .account-form input:focus{background:#111c2f;border-color:#38bdf8}
+.dark .forum-form fieldset{border-color:rgba(148,163,184,0.35)}
+.dark .forum-sublabel,.dark .account-card-intro{color:#e2e8f0}
+.dark .forum-error,.dark .account-error{color:#fca5a5}
+.dark .forum-warning,.dark .forum-locked{color:#fcd34d}
+.dark .forum-success,.dark .account-success{color:#86efac}
+.dark .forum-pill{background:rgba(56,189,248,0.2);color:#bae6fd}
+.dark .forum-media-link{color:#bae6fd}
+.dark .forum-links a,.dark .account-hint a{color:#bae6fd}
+.dark .account-active-status{color:#e2e8f0}
+.dark .account-warning{color:#fbbf24}
 .dark .card:hover{
   border-color:rgba(56,189,248,0.5);
   box-shadow:

--- a/forums/index.html
+++ b/forums/index.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Community Forum — Extynct Studios</title>
+  <meta name="description" content="Share your builds, feedback, and fan creations with the Extynct Studios community. Posts are saved in your browser." />
+  <link rel="icon" type="image/png" href="/assets/images/8.jpg" />
+  <link rel="apple-touch-icon" href="/assets/images/8.jpg" />
+  <link rel="stylesheet" href="/assets/styles.css" />
+  <script src="/assets/site.js" defer></script>
+  <script src="/assets/community-storage.js" defer></script>
+  <script src="/assets/forum.js" defer></script>
+</head>
+<body>
+  <div data-include="/partials/header.html"></div>
+
+  <main id="forum-root" class="forum">
+    <section class="page-hero">
+      <div class="container">
+        <h1>Community Forum</h1>
+        <p class="forum-subtitle">Sign in with your Extynct Studios account to join conversations, share feedback, and showcase your creations. Everything you post is stored locally in this browser.</p>
+        <a class="btn forum-hero-action" href="/account/">Manage your account</a>
+      </div>
+    </section>
+
+    <section class="container forum-layout">
+      <div class="forum-main">
+        <article class="card forum-session-card" aria-labelledby="forum-session-heading">
+          <div class="card-body">
+            <h2 id="forum-session-heading" class="forum-session-title">Forum access</h2>
+            <p id="forum-session-status" class="forum-session-status" aria-live="polite">Checking your sign-in status…</p>
+            <div class="forum-session-actions">
+              <a id="forum-manage-account" class="btn" href="/account/">Account settings</a>
+              <button type="button" id="forum-signout" class="btn" hidden>Sign out</button>
+            </div>
+          </div>
+        </article>
+
+        <article class="card forum-form-card">
+          <div class="card-body">
+            <h2 class="forum-form-title">Create a post</h2>
+            <p class="forum-storage-note">Posts and attachments live on this device using your browser’s local storage. They won’t sync across devices or other visitors.</p>
+            <form id="forum-form" class="forum-form" novalidate>
+              <p id="forum-form-locked" class="forum-locked" hidden>You need to sign in before posting. <a href="/account/">Create or sign in to an account</a> and then return to the forum.</p>
+
+              <div class="forum-field">
+                <label for="forum-category">Channel</label>
+                <select id="forum-category" name="category">
+                  <option value="General">General</option>
+                  <option value="Showcase">Showcase</option>
+                  <option value="Feedback">Feedback</option>
+                  <option value="Support">Support</option>
+                  <option value="Off Topic">Off Topic</option>
+                </select>
+              </div>
+
+              <div class="forum-field">
+                <label for="forum-title">Post title <span aria-hidden="true">*</span></label>
+                <input id="forum-title" name="title" type="text" maxlength="120" required placeholder="What's on your mind?" />
+              </div>
+
+              <div class="forum-field">
+                <label for="forum-body">Details <span aria-hidden="true">*</span></label>
+                <textarea id="forum-body" name="body" rows="5" maxlength="2000" required placeholder="Share context, progress, or questions…"></textarea>
+              </div>
+
+              <fieldset class="forum-field">
+                <legend>Media (optional)</legend>
+                <p class="forum-field-help">Attach a file (images up to 2&nbsp;MB, videos up to 6&nbsp;MB) or drop in a direct link. Everything stays on this device.</p>
+                <label class="forum-sublabel" for="forum-media-file">Upload from device</label>
+                <input id="forum-media-file" name="mediaFile" type="file" accept="image/*,video/*" />
+                <label class="forum-sublabel" for="forum-media-link">Or paste a media link</label>
+                <input id="forum-media-link" name="mediaLink" type="url" placeholder="https://example.com/clip.mp4" inputmode="url" />
+              </fieldset>
+
+              <p id="forum-form-error" class="forum-error" role="alert" hidden></p>
+              <p id="forum-form-success" class="forum-success" role="status" hidden></p>
+              <p id="forum-storage-warning" class="forum-warning" hidden>Heads up: your browser blocked local storage, so posts and sign-ins will disappear after you close this tab.</p>
+
+              <button type="submit" class="btn btn-primary forum-submit">Share post</button>
+            </form>
+          </div>
+        </article>
+
+        <section class="forum-threads">
+          <header class="forum-threads-header">
+            <h2>Latest activity</h2>
+          </header>
+          <p id="forum-empty" class="forum-empty" hidden>No posts yet. Be the first to start a conversation!</p>
+          <div id="forum-posts" class="forum-thread-list" aria-live="polite"></div>
+        </section>
+      </div>
+
+      <aside class="forum-sidebar">
+        <article class="card">
+          <div class="card-body">
+            <h2 class="forum-sidebar-title">Posting guidelines</h2>
+            <ul class="forum-guidelines">
+              <li>Keep feedback constructive and actionable.</li>
+              <li>Tag spoilers and major plot beats.</li>
+              <li>Credit artists if you share fan work.</li>
+              <li>Use the Support channel for bug reports or tech issues.</li>
+              <li>Flag anything unsafe via <a href="mailto:hello@extynctstudios.com">hello@extynctstudios.com</a>.</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="card">
+          <div class="card-body">
+            <h2 class="forum-sidebar-title">Quick links</h2>
+            <ul class="forum-links">
+              <li><a href="https://discord.extynctstudios.com/" target="_blank" rel="noopener">Official Discord</a></li>
+              <li><a href="/news/">Latest devlogs</a></li>
+              <li><a href="/games/">Playtest builds</a></li>
+              <li><a href="/privacy-policy.html">Privacy policy</a></li>
+            </ul>
+          </div>
+        </article>
+      </aside>
+    </section>
+  </main>
+
+  <div data-include="/partials/footer.html"></div>
+</body>
+</html>

--- a/partials/header.html
+++ b/partials/header.html
@@ -8,6 +8,8 @@
       <a class="nav-btn" href="/games/">Games</a>
       <a class="nav-btn" href="/news/">News</a>
       <a class="nav-btn" href="/team/">Team & Thanks</a>
+      <a class="nav-btn" href="/account/">Account</a>
+      <a class="nav-btn" href="/forums/">Community Forum</a>
       <button class="nav-btn" type="button" onclick="toggleTheme()">Toggle Theme</button>
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- replace the GitHub-backed persistence flow with a shared browser storage helper that keeps accounts, sessions, and posts locally
- refresh the account and forum pages plus their scripts to reflect local-only storage, success messaging, and attachment limits
- update styles and documentation to explain the new workflow and remove the old repository data artifacts

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68edda5297948332a26c9759c48ba134